### PR TITLE
feat: teleport package response ability for mocking client

### DIFF
--- a/source/MiaoNet.MockClient/MockInstance.cs
+++ b/source/MiaoNet.MockClient/MockInstance.cs
@@ -12,7 +12,7 @@ namespace MiaoNet.MockClient;
 
 public sealed class MockInstance : IPacketSerializationContext, IDisposable
 {
-    private static readonly Version ClientVersion = new(0, 4, 3);
+    private static readonly Version ClientVersion = new(0, 4, 4);
 
     private Vector2 position;
 
@@ -221,6 +221,34 @@ public sealed class MockInstance : IPacketSerializationContext, IDisposable
         if (packet is PacketPing packetPing)
         {
             packetQueue.Enqueue(new PacketPong() { RequestID = packetPing.RequestID });
+            return;
+        }
+
+        if (packet is PacketBeTeleportedRequest teleportRequest)
+        {
+            Log($"Received teleport request from player {teleportRequest.SourcePlayerID}");
+            var session = new PlayerSessionData(
+                position: position,
+                respawnPoint: position,
+                inventory: new PlayerSessionData.PlayerInventory(1, false, true, false),
+                stringFlags: Array.Empty<string>(),
+                levelStringFlags: Array.Empty<string>(),
+                strawberries: Array.Empty<PlayerSessionData.StringIntPair>(),
+                doNotLoad: Array.Empty<PlayerSessionData.StringIntPair>(),
+                keys: Array.Empty<PlayerSessionData.StringIntPair>(),
+                counters: Array.Empty<PlayerSessionData.StringIntPair>(),
+                startCheckpoint: null,
+                colorGrade: null,
+                summitGems: 0,
+                flags: PlayerSessionData.SessionFlags.FirstLevel,
+                lightingAlphaAdd: 0f,
+                bloomBaseAdd: 0f,
+                darkRoomAlpha: 0f,
+                time: 0,
+                coreMode: CoreModes.None
+            );
+            var response = new PacketBeTeleportedResponse(session) { RequestID = teleportRequest.RequestID };
+            packetQueue.Enqueue(response);
             return;
         }
     }


### PR DESCRIPTION
为mocking client增加了传送数据包响应并更新版本号到0.4.4以适应服务器版本。
用于测试新增random-teleport功能。