### PR TITLE
Enhancement: Random teleport command

### DIFF
--- a/source/MiaoNet.Client/Command/MiaoNetCommand.Commands.cs
+++ b/source/MiaoNet.Client/Command/MiaoNetCommand.Commands.cs
@@ -378,13 +378,16 @@ partial class MiaoNetCommand
 
     private static string? RandomTeleport(Context context)
     {
-        var error = GetRandomNotSelfPlayer(context, out var randomPlayer);
+        var error = GetRandomNotSelfPlayer(context, out var player);
         if (error is not null)
-        {
             return error;
-        }
-        // TODO waiting for modifying teleport logic.
-        return null;
+
+        return MiaoNetModule.Settings.TeleportBehaviour switch
+        {
+            TeleportBehaviour.NoSession => TeleportNoSessionTo(context, player!),
+            TeleportBehaviour.WithSession => TeleportWithSessionTo(context, player!),
+            _ => null,
+        };
     }
     #endregion
 

--- a/source/MiaoNet.Client/Command/MiaoNetCommand.Commands.cs
+++ b/source/MiaoNet.Client/Command/MiaoNetCommand.Commands.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Celeste.Mod.ChatInputBox;
 using MiaoNet.Shared;
@@ -126,6 +127,13 @@ partial class MiaoNetCommand
                 onExecute: new ExecuteHandler(MapChat)
             ),
             new MiaoNetCommand(
+                name: "random-teleport",
+                aliases: [ "rtp" ],
+                segments: [],
+                captureRestSegments: false,
+                onExecute: new ExecuteHandler(RandomTeleport)
+            ),
+            new MiaoNetCommand(
                 name: "channel",
                 aliases: [ "join" ],
                 segments: [CommandSegmentType.Channel],
@@ -139,6 +147,7 @@ partial class MiaoNetCommand
     private static string PlayerNotFound => Dialog.Clean("miaonet_command_status_player_not_found");
     private static string PlayerNotInMap => Dialog.Clean("miaonet_command_status_player_not_in_map");
     private static string PlayerMapMissing => Dialog.Clean("miaonet_command_status_player_map_missing");
+    private static string NoAvailablePlayer => Dialog.Clean("miaonet_command_status_no_available_player");
     private static string NeedInMap => Dialog.Clean("miaonet_command_status_need_in_level");
     private static string CommandHelpTitle => Dialog.Clean("miaonet_command_help_title");
     private static string CommandHelpNotFound => Dialog.Clean("miaonet_command_help_not_found");
@@ -361,6 +370,17 @@ partial class MiaoNetCommand
             TeleportBehaviour.WithSession => TeleportWithSession(context),
             _ => null,
         };
+
+    private static string? RandomTeleport(Context context)
+    {
+        var error = GetRandomNotSelfPlayer(context, out var randomPlayer);
+        if (error is not null)
+        {
+            return error;
+        }
+        // TODO waiting for modifying teleport logic.
+        return null;
+    }
     #endregion
 
     #region Help
@@ -596,6 +616,23 @@ partial class MiaoNetCommand
         return null;
     }
 
+
+    private static string? GetRandomNotSelfPlayer(Context context, out OnlinePlayer? player)
+    {
+        player = null;
+        var clientState = context.MiaoNetContext.ClientState!;
+        var allPlayers = from pair in clientState.SelfChannel.Players select pair.Value;
+        var candidates = allPlayers                                                                                                                                                                  
+            .Where(p => EnsurePlayerInExistedMap(p, out _) is null)                 // Teleportable
+            .Where(p => !p.GlobalFlags.HasFlag(PlayerGlobalFlags.TakingGolden))     // Not taking golden
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            return PFormat.Format(NoAvailablePlayer);
+        }
+        player = candidates.ElementAt(Random.Shared.Next(candidates.Count));
+        return null;
+    }
     #endregion
 
 #pragma warning restore CA1305

--- a/source/MiaoNet.Client/Command/MiaoNetCommand.Commands.cs
+++ b/source/MiaoNet.Client/Command/MiaoNetCommand.Commands.cs
@@ -175,21 +175,22 @@ partial class MiaoNetCommand
     }
 
     #region Teleport
-    private static void NotifyTeleportBehaviour(Context context)
+    private static bool NotifyTeleportBehaviourOnce(Context context)
     {
+        if (MiaoNetModule.Settings.TippedTeleport)
+            return false;
+
+        MiaoNetModule.Settings.TippedTeleport = true;
+        MiaoNetModule.Instance.SaveSettings();
         foreach (var item in Dialog.Clean("miaonet_commands_teleport_notice").EnumerateLines())
             context.TipMessage(item.ToString());
+        return true;
     }
 
     private static string? TeleportNoSession(Context context)
     {
-        if (!MiaoNetModule.Settings.TippedTeleport)
-        {
-            MiaoNetModule.Settings.TippedTeleport = true;
-            MiaoNetModule.Instance.SaveSettings();
-            NotifyTeleportBehaviour(context);
+        if (NotifyTeleportBehaviourOnce(context))
             return null;
-        }
 
         string? error;
 
@@ -214,13 +215,8 @@ partial class MiaoNetCommand
 
     private static string? TeleportWithSession(Context context)
     {
-        if (!MiaoNetModule.Settings.TippedTeleport)
-        {
-            MiaoNetModule.Settings.TippedTeleport = true;
-            MiaoNetModule.Instance.SaveSettings();
-            NotifyTeleportBehaviour(context);
+        if (NotifyTeleportBehaviourOnce(context))
             return null;
-        }
 
         string? error;
 

--- a/source/MiaoNet.Client/Command/MiaoNetCommand.Commands.cs
+++ b/source/MiaoNet.Client/Command/MiaoNetCommand.Commands.cs
@@ -198,7 +198,11 @@ partial class MiaoNetCommand
         if (error is not null)
             return error;
 
-        error = EnsurePlayerInExistedMap(player!, out AreaData? area);
+        return TeleportNoSessionTo(context, player!);
+    }
+    private static string? TeleportNoSessionTo(Context context, OnlinePlayer player)
+    {
+    string? error = EnsurePlayerInExistedMap(player!, out AreaData? area);
         if (error is not null)
             return error;
 
@@ -224,7 +228,12 @@ partial class MiaoNetCommand
         if (error is not null)
             return error;
 
-        error = EnsurePlayerInExistedMap(player!, out AreaData? area);
+        return TeleportWithSessionTo(context, player!);
+    }
+    
+    private static string? TeleportWithSessionTo(Context context, OnlinePlayer player)
+    {
+    string? error = EnsurePlayerInExistedMap(player!, out AreaData? area);
         if (error is not null)
             return error;
 

--- a/source/MiaoNet.Client/ModFolder/Dialog/English.txt
+++ b/source/MiaoNet.Client/ModFolder/Dialog/English.txt
@@ -162,6 +162,7 @@ miaonet_command_status_player_not_found= Player "(0)" not found
 miaonet_command_status_player_not_in_map= Player "(0)" is not in a map
 miaonet_command_status_player_is_self= "(0)" is yourself!
 miaonet_command_status_player_map_missing= Map "(1)" where player "(0)" is in is missing
+miaonet_command_status_no_available_player= No player in map & not taking golden strawberry
 miaonet_command_status_channel_not_found= Channel "(0)" not found
 miaonet_command_help_title= == MiaoNet Command Help ((0)) ==
 miaonet_command_help_not_found= Command "(0)" not found

--- a/source/MiaoNet.Client/ModFolder/Dialog/English.txt
+++ b/source/MiaoNet.Client/ModFolder/Dialog/English.txt
@@ -183,6 +183,7 @@ miaonet_commands_teleport_no_session_s0_description= The player that teleported 
 miaonet_commands_teleport_with_session_description= Teleport to a player and fetch their session.
 miaonet_commands_teleport_with_session_s0_name= Player
 miaonet_commands_teleport_with_session_s0_description= The player that teleported to.
+miaonet_commands_random_teleport_description= Teleport to a random player in map and isn't carrying a golden strawberry.
 miaonet_commands_whisper_description= Whipser a message to a player.
 miaonet_commands_whisper_s0_name= Player
 miaonet_commands_whisper_s0_description= The player that will be whispered to.

--- a/source/MiaoNet.Client/ModFolder/Dialog/Simplified Chinese.txt
+++ b/source/MiaoNet.Client/ModFolder/Dialog/Simplified Chinese.txt
@@ -159,6 +159,7 @@ miaonet_command_status_player_not_found= 未找到玩家 "(0)"
 miaonet_command_status_player_not_in_map= 玩家 "(0)" 不在地图内
 miaonet_command_status_player_is_self= "(0)" 是你自己！
 miaonet_command_status_player_map_missing= 本地不存在玩家 "(0)" 所在的地图 "(1)"
+miaonet_command_status_no_available_player= 没有在地图内且未持有金草莓的玩家可作为目标
 miaonet_command_status_channel_not_found= 未找到频道 "(0)"
 miaonet_command_help_title= == MiaoNet 指令帮助 ((0)) ==
 miaonet_command_help_not_found= 未找到指令 "(0)"

--- a/source/MiaoNet.Client/ModFolder/Dialog/Simplified Chinese.txt
+++ b/source/MiaoNet.Client/ModFolder/Dialog/Simplified Chinese.txt
@@ -180,6 +180,7 @@ miaonet_commands_teleport_no_session_s0_description= 要传送到的玩家。
 miaonet_commands_teleport_with_session_description= 携带存档信息地传送到另一个玩家。
 miaonet_commands_teleport_with_session_s0_name= 玩家名称
 miaonet_commands_teleport_with_session_s0_description= 要传送到的玩家。
+miaonet_commands_random_teleport_description= 随机传送到一个未带金的图内玩家
 miaonet_commands_whisper_description= 发送一条私聊信息。
 miaonet_commands_whisper_s0_name= 玩家名称
 miaonet_commands_whisper_s0_description= 私聊的玩家。

--- a/source/MiaoNet.MockClient/MockInstance.cs
+++ b/source/MiaoNet.MockClient/MockInstance.cs
@@ -234,6 +234,34 @@ public sealed class MockInstance : IPacketSerializationContext, IDisposable
             packetQueue.Enqueue(new PacketPong() { RequestID = packetPing.RequestID });
             return;
         }
+
+        if (packet is PacketBeTeleportedRequest teleportRequest)
+        {
+            Log($"Received teleport request from player {teleportRequest.SourcePlayerID}");
+            var session = new PlayerSessionData(
+                position: position,
+                respawnPoint: position,
+                inventory: new PlayerSessionData.PlayerInventory(1, false, true, false),
+                stringFlags: Array.Empty<string>(),
+                levelStringFlags: Array.Empty<string>(),
+                strawberries: Array.Empty<PlayerSessionData.StringIntPair>(),
+                doNotLoad: Array.Empty<PlayerSessionData.StringIntPair>(),
+                keys: Array.Empty<PlayerSessionData.StringIntPair>(),
+                counters: Array.Empty<PlayerSessionData.StringIntPair>(),
+                startCheckpoint: null,
+                colorGrade: null,
+                summitGems: 0,
+                flags: PlayerSessionData.SessionFlags.FirstLevel,
+                lightingAlphaAdd: 0f,
+                bloomBaseAdd: 0f,
+                darkRoomAlpha: 0f,
+                time: 0,
+                coreMode: CoreModes.None
+            );
+            var response = new PacketBeTeleportedResponse(session) { RequestID = teleportRequest.RequestID };
+            packetQueue.Enqueue(response);
+            return;
+        }
     }
 
     private void Log(string msg)


### PR DESCRIPTION
#17 随机传送指令实现
1. 注册random-teleport指令和其handler
2. 增添了新的指令错误信息”miaonet_command_status_no_available_player“
3. 重构teleport handler变体，将“解析玩家名”与“在首次tp时告知tp行为”逻辑提取，拆分为handler入口和TeleportNo/WithSession**To**方法，供RandomTeleport随机到目标玩家后复用传送逻辑。

已在本地启动Server和Mocking Client测试，结果无回归，指令行为符合预期
效果展示：
<img width="417" height="121" alt="image" src="https://github.com/user-attachments/assets/f7cf6dce-b8bd-4c93-9940-e8fe87f64337" />
