### PR TITLE
fix(build): 修复 Release 下共享 TLS 异常缺失

### DIFF
--- a/source/MiaoNet.ClientShared/MiaoSslException.cs
+++ b/source/MiaoNet.ClientShared/MiaoSslException.cs
@@ -1,11 +1,11 @@
-﻿using System.Net.Security;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-namespace Celeste.Mod.MiaoNet;
+namespace MiaoNet.ClientShared;
 
-// unluckly we can't get anything from AuthenticationException
-// so we need to handle these manually...
-internal class MiaoSslException : Exception
+// AuthenticationException does not expose the certificate validation details,
+// so preserve them for the client to present a useful connection error.
+internal sealed class MiaoSslException : Exception
 {
     public SslPolicyErrors SslPolicyErrors { get; }
 


### PR DESCRIPTION
## 问题

完整解决方案在 Release 配置下无法编译。

当 `USE_LOCALHOST_PFX` 未启用时，`MiaoServerConnection` 的正式证书校验逻辑会引用 `MiaoSslException`。但是该异常原本位于 `MiaoNet.Client/Misc`，命名空间为 `Celeste.Mod.MiaoNet`。

`MiaoServerConnection` 属于 `MiaoNet.ClientShared` 共享源码，同时会被以下两个项目编译：

- `MiaoNet.Client`
- `MiaoNet.MockClient`

因此，原来的异常类型既无法被共享连接实现直接解析，也没有被 MockClient 编译，最终导致 Release 构建出现 `CS0246`。

Debug 配置默认使用本地 PFX，相关正式证书校验代码会被条件编译排除，所以此前没有暴露该问题。

## 原因

`MiaoNet.ClientShared` 当前不是一个独立运行时程序集，而是一组由 Client 和 MockClient 分别链接编译的共享源码。

由共享连接代码抛出的内部异常也必须属于这组共享源码，才能在两个使用方中分别生成对应的内部类型。

## 修改

- 将 `MiaoSslException` 从 `MiaoNet.Client/Misc` 移动到 `MiaoNet.ClientShared`。
- 将命名空间调整为 `MiaoNet.ClientShared`。
- 继续保持 `internal`，因为它只是连接实现细节，不需要成为公开 API。
- 将类型标记为 `sealed`。
- 更新注释，说明使用自定义异常是为了保留 `AuthenticationException` 没有提供的证书策略错误和证书链状态，以便客户端显示准确的连接错误。

## 兼容性

此修改不会改变：

- 网络协议格式；
- TLS 验证规则；
- 证书错误处理结果；
- 对外公开 API。

它只修正共享源码的归属，使现有正式证书校验逻辑可以在 Client 和 MockClient 中正确编译。

## 验证

- 完整 Release 解决方案构建通过：
  - 0 个警告；
  - 0 个错误；
  - Client 编译成功；
  - MockClient 编译成功。
- 完整 Debug 解决方案构建通过：
  - 0 个警告；
  - 0 个错误。
- Debug 单元测试通过：
  - 90/90。
