### PR TITLE
test(auth): 覆盖 OAuth 刷新凭据的重复认证

### DIFF
--- a/source/MiaoNet.Server/AssemblyInfo.cs
+++ b/source/MiaoNet.Server/AssemblyInfo.cs
@@ -1,3 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 [module: SkipLocalsInit]
+[assembly: InternalsVisibleTo("MiaoNet.UnitTest")]

--- a/source/MiaoNet.Server/Server/Authentication/CeleMiaoAuthenticator.cs
+++ b/source/MiaoNet.Server/Server/Authentication/CeleMiaoAuthenticator.cs
@@ -27,6 +27,15 @@ public sealed partial class CeleMiaoAuthenticator : IMiaoAuthenticator
     public const string EndPointAuth = "api/celeste/user?access_token=";
 
     public CeleMiaoAuthenticator(IOptions<MiaoServerOptions> options, ILogger<CeleMiaoAuthenticator> logger)
+        : this(options, logger, new HttpClient())
+    {
+    }
+
+    internal CeleMiaoAuthenticator(
+        IOptions<MiaoServerOptions> options,
+        ILogger<CeleMiaoAuthenticator> logger,
+        HttpClient httpClient
+    )
     {
         var authOptions = options.Value.Authentication;
         if (authOptions.ClientID is null || authOptions.ClientSecret is null || authOptions.EncryptionPassword is null)
@@ -44,7 +53,7 @@ public sealed partial class CeleMiaoAuthenticator : IMiaoAuthenticator
             // blame bbs
             NumberHandling = JsonNumberHandling.AllowReadingFromString
         };
-        httpClient = new HttpClient();
+        this.httpClient = httpClient;
         // TODO add version info
         string ua = "MiaoNet.Server.CeleMiaoAuthenticator";
         logger.LogInformation(AppEvents.Auth, "Using User-Agent \"{ua}\"", ua);

--- a/source/MiaoNet.UnitTest/CeleMiaoAuthenticatorTests.cs
+++ b/source/MiaoNet.UnitTest/CeleMiaoAuthenticatorTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using MiaoNet.Server;
+using MiaoNet.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace MiaoNet.UnitTest;
+
+[TestClass]
+public sealed class CeleMiaoAuthenticatorTests
+{
+    [TestMethod]
+    public async Task RefreshedTokenDataCanAuthenticateAgainWithoutAnotherRefresh()
+    {
+        var handler = new OAuthHandler();
+        using var httpClient = new HttpClient(handler);
+        var authenticator = new CeleMiaoAuthenticator(
+            CreateOptions(),
+            NullLogger<CeleMiaoAuthenticator>.Instance,
+            httpClient
+        );
+
+        AuthenticationResult initialResult = await authenticator.AuthenticateAsync(
+            Encoding.UTF8.GetBytes("authorization-code"),
+            isAuthorize: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(AuthenticationResultType.Success, initialResult.Type);
+        Assert.IsNotNull(initialResult.TokenData);
+
+        AuthenticationResult refreshResult = await authenticator.AuthenticateAsync(
+            initialResult.TokenData,
+            isAuthorize: false,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(AuthenticationResultType.Success, refreshResult.Type);
+        Assert.IsNotNull(refreshResult.TokenData);
+        CollectionAssert.AreNotEqual(initialResult.TokenData, refreshResult.TokenData);
+
+        AuthenticationResult reconnectResult = await authenticator.AuthenticateAsync(
+            refreshResult.TokenData,
+            isAuthorize: false,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(AuthenticationResultType.Success, reconnectResult.Type);
+        Assert.AreEqual("refreshed-access-token", handler.LastAuthenticatedAccessToken);
+        Assert.AreEqual(1, handler.RefreshRequestCount);
+    }
+
+    private static IOptions<MiaoServerOptions> CreateOptions()
+    {
+        var announcements = new AnnouncementsStrings(string.Empty, string.Empty, string.Empty);
+        return Options.Create(new MiaoServerOptions
+        {
+            Authentication = new AuthenticationOptions
+            {
+                ClientID = "client-id",
+                ClientSecret = "client-secret",
+                EncryptionPassword = "encryption-password"
+            },
+            Certificate = new CertificateOptions(),
+            Announcements = new LocalizedOptions<AnnouncementsStrings>
+            {
+                SChinese = announcements,
+                English = announcements
+            }
+        });
+    }
+
+    private sealed class OAuthHandler : HttpMessageHandler
+    {
+        public int RefreshRequestCount { get; private set; }
+
+        public string? LastAuthenticatedAccessToken { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/oauth/token")
+            {
+                string requestJson = await request.Content!.ReadAsStringAsync(cancellationToken);
+                using JsonDocument requestDocument = JsonDocument.Parse(requestJson);
+                string grantType = requestDocument.RootElement.GetProperty("grant_type").GetString()!;
+
+                if (grantType == "authorization_code")
+                {
+                    return JsonResponse("""
+                        {
+                          "access_token": "initial-access-token",
+                          "expires_in": -1,
+                          "token_type": "Bearer",
+                          "scope": "celeste",
+                          "refresh_token": "refresh-token"
+                        }
+                        """);
+                }
+
+                Assert.AreEqual("refresh_token", grantType);
+                Assert.AreEqual("refresh-token", requestDocument.RootElement.GetProperty("refresh_token").GetString());
+                RefreshRequestCount++;
+                Assert.AreEqual(1, RefreshRequestCount, "A valid refreshed token must not be refreshed again on reconnect.");
+                return JsonResponse("""
+                    {
+                      "access_token": "refreshed-access-token",
+                      "expires_in": 3600,
+                      "token_type": "Bearer",
+                      "scope": "celeste"
+                    }
+                    """);
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/celeste/user")
+            {
+                LastAuthenticatedAccessToken = GetQueryValue(request.RequestUri.Query, "access_token");
+                return JsonResponse("""
+                    {
+                      "id": 42,
+                      "username": "OAuth tester",
+                      "avatar_url": null,
+                      "is_email_confirmed": 1,
+                      "prefix": null,
+                      "color": "#123456",
+                      "suspended_until": null,
+                      "suspend_message": null,
+                      "suspend_reason": null
+                    }
+                    """);
+            }
+
+            Assert.Fail($"Unexpected request: {request.Method} {request.RequestUri}");
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        }
+
+        private static string? GetQueryValue(string query, string name)
+        {
+            foreach (string pair in query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                string[] parts = pair.Split('=', 2);
+                if (Uri.UnescapeDataString(parts[0]) == name)
+                    return parts.Length == 2 ? Uri.UnescapeDataString(parts[1]) : string.Empty;
+            }
+            return null;
+        }
+
+        private static HttpResponseMessage JsonResponse(string json)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            response.Headers.Date = DateTimeOffset.UtcNow;
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
## 当前范围

上游 `wip` 的 `e3b650e` 已经修正刷新凭据序列化和加密错误。本 PR 重基后保留仍未进入上游的回归保障：

- 为 `CeleMiaoAuthenticator` 增加内部 `HttpClient` 注入入口，生产构造行为不变；
- 增加完整 OAuth 生命周期测试：授权、过期、刷新、保存刷新凭据、再次认证；
- 验证再次认证使用刷新后的 access token，并且有效 token 不会重复刷新。

不改变网络协议、token 格式、AES-CBC 格式或生产 HTTP 请求行为。

## 最新验证

- 已重基到最新 `wip`，落后提交数为 0；
- Debug 完整解决方案：0 警告、0 错误；
- 单分支测试：91/91；
- 与其余有效修复组合测试：184/184。