### PR TITLE
fix(auth): 为 Release 默认启用 CeleMiao 认证

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ MiaoNet 是面向大量玩家场景的 Celeste 联机项目，也是对 CelesteN
 
 项目仍处于早期开发阶段，主要开发分支为 `wip`。当前仓库包含 Everest 客户端 Mod、独立服务端、共享协议代码、模拟客户端、聊天组件、测试和数据包检查工具。
 
+## 编译时认证模式
+
+`Release` 默认启用 CeleMiao OAuth 认证，并要求服务端配置
+`MiaoServer:Authentication` 下的 `ClientID`、`ClientSecret` 和
+`EncryptionPassword`；任一配置缺失或为空时，服务端会拒绝启动。
+`Debug` 默认保留无需论坛账号的本地开发认证。
+
+认证模式会同时影响客户端登录流程和服务端认证器，两端应使用相同设置构建。如需显式覆盖默认值，可向 MSBuild 传入
+`-p:UseCeleMiaoAuth=true` 或 `-p:UseCeleMiaoAuth=false`。发布到公网的构建不应关闭该选项。
+
 ## 项目结构
 
 | 路径 | 说明 |

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -4,7 +4,8 @@
     <LangVersion>preview</LangVersion>
     <UseLocalhostPfx>false</UseLocalhostPfx>
     <UseLocalhostPfx Condition="$(Configuration) == 'Debug'">true</UseLocalhostPfx>
-    <UseCeleMiaoAuth>false</UseCeleMiaoAuth>
+    <UseCeleMiaoAuth Condition="'$(UseCeleMiaoAuth)' == '' and '$(Configuration)' == 'Release'">true</UseCeleMiaoAuth>
+    <UseCeleMiaoAuth Condition="'$(UseCeleMiaoAuth)' == ''">false</UseCeleMiaoAuth>
 
     <DefineConstants Condition="$(UseLocalhostPfx) == 'true'">$(DefineConstants);USE_LOCALHOST_PFX</DefineConstants>
     <DefineConstants Condition="$(UseCeleMiaoAuth) == 'true'">$(DefineConstants);USE_CELEMIAO_AUTH</DefineConstants>

--- a/source/MiaoNet.Client/Connection/MiaoNetContext.cs
+++ b/source/MiaoNet.Client/Connection/MiaoNetContext.cs
@@ -205,7 +205,7 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
     private void OnInitialized(MiaoServerConnection connection, PacketClientInitial packetClientInitial)
     {
 #if USE_CELEMIAO_AUTH
-        MiaoNetModule.Settings.LastName = clientInitial.SelfPlayerInfo.Name;
+        MiaoNetModule.Settings.LastName = packetClientInitial.SelfPlayerInfo.Name;
 #endif
         clientState = new(packetClientInitial);
         PlayerPresenceMessage = packetClientInitial.PlayerPresenceMessage;

--- a/source/MiaoNet.Server/Server/Authentication/CeleMiaoAuthenticator.cs
+++ b/source/MiaoNet.Server/Server/Authentication/CeleMiaoAuthenticator.cs
@@ -38,9 +38,13 @@ public sealed partial class CeleMiaoAuthenticator : IMiaoAuthenticator
     )
     {
         var authOptions = options.Value.Authentication;
-        if (authOptions.ClientID is null || authOptions.ClientSecret is null || authOptions.EncryptionPassword is null)
+        if (string.IsNullOrWhiteSpace(authOptions.ClientID)
+            || string.IsNullOrWhiteSpace(authOptions.ClientSecret)
+            || string.IsNullOrWhiteSpace(authOptions.EncryptionPassword))
         {
-            throw new Exception("ClientID, ClientSecret and EncryptionPassword must be configured when using CeleMiaoAuthenticator.");
+            throw new InvalidOperationException(
+                "ClientID, ClientSecret and EncryptionPassword must be configured when using CeleMiaoAuthenticator."
+            );
         }
         clientID = authOptions.ClientID;
         clientSecret = authOptions.ClientSecret;

--- a/source/MiaoNet.UnitTest/CeleMiaoAuthenticatorTests.cs
+++ b/source/MiaoNet.UnitTest/CeleMiaoAuthenticatorTests.cs
@@ -159,4 +159,41 @@ public sealed class CeleMiaoAuthenticatorTests
             return response;
         }
     }
+
+    [TestMethod]
+    [DataRow(null, "client-secret", "encryption-password")]
+    [DataRow("client-id", null, "encryption-password")]
+    [DataRow("client-id", "client-secret", null)]
+    [DataRow(" ", "client-secret", "encryption-password")]
+    [DataRow("client-id", "\t", "encryption-password")]
+    [DataRow("client-id", "client-secret", "\r\n")]
+    public void ConstructorRejectsMissingAuthenticationConfiguration(
+        string? clientID,
+        string? clientSecret,
+        string? encryptionPassword
+    )
+    {
+        MiaoServerOptions serverOptions = new()
+        {
+            Certificate = new CertificateOptions(),
+            Authentication = new AuthenticationOptions
+            {
+                ClientID = clientID,
+                ClientSecret = clientSecret,
+                EncryptionPassword = encryptionPassword
+            },
+            Announcements = new LocalizedOptions<AnnouncementsStrings>
+            {
+                SChinese = new AnnouncementsStrings(string.Empty, string.Empty, string.Empty),
+                English = new AnnouncementsStrings(string.Empty, string.Empty, string.Empty)
+            }
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            new CeleMiaoAuthenticator(
+                Options.Create(serverOptions),
+                NullLogger<CeleMiaoAuthenticator>.Instance
+            )
+        );
+    }
 }


### PR DESCRIPTION
## 前置 PR

- 在 #35 后合并，以确保标准 Release 解决方案可以完整编译。
- 在 #36 后合并；两个 PR 都会修改 `CeleMiaoAuthenticator` 和对应测试文件。
- #36 合并后，本分支需要 rebase 到最新 `wip`，保留两组认证测试并重新执行完整验证。

## 问题

当前构建配置无条件设置：

```xml
<UseCeleMiaoAuth>false</UseCeleMiaoAuth>
```

因此 Debug 和 Release 默认都会编译并使用开发认证流程。

服务端在未启用 CeleMiao 认证时会注册 `CustomAuthenticator`。该认证器直接接受客户端提交的 `PlayerInfo` 并返回认证成功，适合本地开发，但不适合公网生产部署。

如果按仓库默认配置构建和发布 Release 服务端，客户端可以自行提交 AuthID、名称、前缀和头像等身份信息，无法可靠应用论坛身份、封禁和账号管理规则。

## 原因

认证方式通过 `USE_CELEMIAO_AUTH` 条件编译同时控制客户端登录流程和服务端认证器注册。

由于 `UseCeleMiaoAuth` 对所有构建配置都固定为 `false`，生产 Release 构建不会启用真实认证，而且构建过程不会给出明显错误。

这使开发认证意外成为了默认发布行为。

## 修改

- Release 在没有显式设置时默认使用 `UseCeleMiaoAuth=true`。
- Debug 在没有显式设置时继续使用 `UseCeleMiaoAuth=false`。
- 保留通过以下 MSBuild 参数显式覆盖认证模式的能力：

  ```text
  -p:UseCeleMiaoAuth=true
  -p:UseCeleMiaoAuth=false
  ```

- CeleMiao 认证启用时，以下配置为 `null`、空字符串或纯空白都会拒绝启动：
  - `ClientID`
  - `ClientSecret`
  - `EncryptionPassword`
- 使用明确的 `InvalidOperationException` 报告认证配置缺失。
- 修复 CeleMiao 条件编译路径中错误引用 `clientInitial` 的问题，改为使用当前方法参数 `packetClientInitial`。
- 在 README 中记录 Debug、Release 的默认认证模式、必要配置和显式覆盖方法。

## 行为变化

这是有意的 Release 部署行为变更：

- Debug 构建继续使用本地开发认证，不影响日常开发。
- Release 构建默认要求 CeleMiao OAuth 配置。
- Release 缺少认证配置时会拒绝启动，而不是回退到不可信的开发认证。
- 如确实需要构建不使用 CeleMiao 的 Release，可以显式传入：

  ```text
  -p:UseCeleMiaoAuth=false
  ```

面向公网部署的服务端不应关闭该选项。

客户端与服务端应使用一致的认证模式构建，因为该选项同时影响客户端登录数据和服务端认证器。

## 兼容性

此修改不会改变：

- 已启用 CeleMiao 时的 OAuth 协议；
- token 序列化和加密格式；
- 客户端与服务端的认证包结构；
- Debug 默认开发流程。

主要兼容性影响是：以前依赖默认 Release 开发认证的部署，现在必须配置 CeleMiao 凭据，或者明确选择关闭 CeleMiao 认证。

## 验证

新增 6 组认证配置测试，覆盖：

- `ClientID` 为 `null`；
- `ClientSecret` 为 `null`；
- `EncryptionPassword` 为 `null`；
- `ClientID` 为空白；
- `ClientSecret` 为空白；
- `EncryptionPassword` 为空白。

验证结果：

- Debug 默认值：
  - `UseCeleMiaoAuth=false`；
  - 不包含 `USE_CELEMIAO_AUTH`。
- Release 默认值：
  - `UseCeleMiaoAuth=true`；
  - 包含 `USE_CELEMIAO_AUTH`。
- Release 显式关闭认证：生效。
- Debug 显式开启认证：生效。
- 未配置凭据的 Release 服务端启动测试：
  - 按预期立即失败；
  - 明确报告缺失认证配置。
- Debug 完整解决方案构建通过：
  - 0 个警告；
  - 0 个错误。
- Debug 单元测试通过：96/96。
- Release 服务端构建通过：
  - 0 个警告；
  - 0 个错误。
- Release 单元测试通过：96/96。
