### PR TITLE
fix(protocol): 限制远端池化字符串增长

### DIFF
--- a/source/MiaoNet.Shared/Helpers/PooledStringManager.cs
+++ b/source/MiaoNet.Shared/Helpers/PooledStringManager.cs
@@ -7,13 +7,23 @@ using System.Collections.Immutable;
 #endif
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 
 namespace MiaoNet.Shared;
 
 [DebuggerDisplay("LocalCount = {LocalCount}, RemoteCount = {RemoteCount}")]
 public sealed class PooledStringManager
 {
+    // Initial, locally-known strings are trusted and don't consume these per-peer learning quotas.
+    public const int MaxRemoteEntries = 4096;
+    public const int MaxRemoteStringUtf8Bytes = 1024;
+    public const int MaxRemoteTotalUtf8Bytes = 1024 * 1024;
+
     private int currentLocalID;
+    // Local and remote ID spaces both start after the shared initial strings, but advance independently.
+    private int nextRemoteID;
+    private int remoteLearnedCount;
+    private int remoteLearnedUtf8Bytes;
 #if CONCURRENT
     // only used to resolve PooledString from remote
     private ImmutableDictionary<int, string> idToString;
@@ -32,14 +42,17 @@ public sealed class PooledStringManager
 
     public PooledStringManager(IEnumerable<string> initialStrings)
     {
+        ArgumentNullException.ThrowIfNull(initialStrings);
+        string[] initial = initialStrings.ToArray();
 #if CONCURRENT
-        idToString = (initialStrings.Select((s, i) => new KeyValuePair<int, string>(i + 1, s))).ToImmutableDictionary();
-        stringToID = (initialStrings.Select((s, i) => new KeyValuePair<string, int>(s, i + 1))).ToImmutableDictionary();
+        idToString = (initial.Select((s, i) => new KeyValuePair<int, string>(i + 1, s))).ToImmutableDictionary();
+        stringToID = (initial.Select((s, i) => new KeyValuePair<string, int>(s, i + 1))).ToImmutableDictionary();
 #else
-        idToString = new(initialStrings.Select((s, i) => new KeyValuePair<int, string>(i + 1, s)));
-        stringToID = new(initialStrings.Select((s, i) => new KeyValuePair<string, int>(s, i + 1)));
+        idToString = new(initial.Select((s, i) => new KeyValuePair<int, string>(i + 1, s)));
+        stringToID = new(initial.Select((s, i) => new KeyValuePair<string, int>(s, i + 1)));
 #endif
-        currentLocalID = initialStrings.Count() + 1;
+        currentLocalID = initial.Length + 1;
+        nextRemoteID = initial.Length + 1;
     }
 
     public bool GetOrCreateID(string value, out int id)
@@ -67,6 +80,9 @@ public sealed class PooledStringManager
 
     public string GetAndRecord(int id, string? value)
     {
+        if (id <= 0)
+            throw new InvalidDataException(string.Format(CultureInfo.InvariantCulture, SR.InvalidPooledStringID, id));
+
         if (idToString.TryGetValue(id, out string? firstFoundValue))
         {
             if (value is not null && firstFoundValue != value)
@@ -87,15 +103,56 @@ public sealed class PooledStringManager
 
                 if (value is null)
                     throw new InvalidDataException(string.Format(CultureInfo.InvariantCulture, SR.MissingPooledString, id));
+                ValidateNewRemoteEntry(id, value, out int utf8ByteCount);
                 idToString = idToString.Add(id, value);
+                RecordNewRemoteEntry(utf8ByteCount);
                 return value;
             }
 #else
             if (value is null)
                 throw new InvalidDataException(string.Format(CultureInfo.InvariantCulture, SR.MissingPooledString, id));
+            ValidateNewRemoteEntry(id, value, out int utf8ByteCount);
             idToString.Add(id, value);
+            RecordNewRemoteEntry(utf8ByteCount);
             return value;
 #endif
         }
+    }
+
+    private void ValidateNewRemoteEntry(int id, string value, out int utf8ByteCount)
+    {
+        if (id != nextRemoteID)
+        {
+            throw new InvalidDataException(string.Format(
+                CultureInfo.InvariantCulture,
+                SR.UnexpectedPooledStringID,
+                id,
+                nextRemoteID
+            ));
+        }
+
+        if (remoteLearnedCount >= MaxRemoteEntries)
+            throw new InvalidDataException(SR.PooledStringEntryLimitExceeded);
+
+        utf8ByteCount = Encoding.UTF8.GetByteCount(value);
+        if (utf8ByteCount > MaxRemoteStringUtf8Bytes)
+        {
+            throw new InvalidDataException(string.Format(
+                CultureInfo.InvariantCulture,
+                SR.PooledStringValueTooLarge,
+                utf8ByteCount,
+                MaxRemoteStringUtf8Bytes
+            ));
+        }
+
+        if (remoteLearnedUtf8Bytes > MaxRemoteTotalUtf8Bytes - utf8ByteCount)
+            throw new InvalidDataException(SR.PooledStringTotalBytesExceeded);
+    }
+
+    private void RecordNewRemoteEntry(int utf8ByteCount)
+    {
+        remoteLearnedCount++;
+        remoteLearnedUtf8Bytes += utf8ByteCount;
+        nextRemoteID++;
     }
 }

--- a/source/MiaoNet.Shared/SR.cs
+++ b/source/MiaoNet.Shared/SR.cs
@@ -6,6 +6,16 @@ internal static class SR
         = "A pooled string(id {0}) is missing but doesn't contain value.";
     public const string PooledStringValueNotMatch
         = "A pooled string is found locally(\"{0}\") but remote provided a different value(\"{1}\").";
+    public const string InvalidPooledStringID
+        = "A pooled string id must be positive, but remote provided {0}.";
+    public const string UnexpectedPooledStringID
+        = "A new pooled string has id {0}, but the next expected id is {1}.";
+    public const string PooledStringEntryLimitExceeded
+        = "The remote pooled string entry limit has been exceeded.";
+    public const string PooledStringValueTooLarge
+        = "A remote pooled string uses {0} UTF-8 bytes, exceeding the limit of {1}.";
+    public const string PooledStringTotalBytesExceeded
+        = "The remote pooled string UTF-8 byte limit has been exceeded.";
     public const string TypeMustAtLeaseImplContextualPacket
         = "A packet type being registered must at lease implement IContextualPacket.";
     public const string TypeIsNotRegisteredAsAPacket

--- a/source/MiaoNet.UnitTest/PooledStringManagerTests.cs
+++ b/source/MiaoNet.UnitTest/PooledStringManagerTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Reflection;
+using System.Globalization;
 using System.Text;
 using MiaoNet.Shared;
 
@@ -60,6 +59,74 @@ public class PooledStringManagerTests
     }
 
     [TestMethod]
+    public void InitialStrings_KeepOneBasedIDsAndSetNextIDForBothDirections()
+    {
+        string[] initial = ["KnownA", "KnownB"];
+        var m = new PooledStringManager(initial);
+
+        Assert.IsTrue(m.GetOrCreateID("KnownA", out int knownLocalID));
+        Assert.AreEqual(1, knownLocalID);
+        Assert.IsFalse(m.GetOrCreateID("NewLocal", out int newLocalID));
+        Assert.AreEqual(3, newLocalID);
+
+        Assert.AreEqual("KnownA", m.GetAndRecord(1, null));
+        Assert.AreEqual("KnownB", m.GetAndRecord(2, "KnownB"));
+        Assert.AreEqual("NewRemote", m.GetAndRecord(3, "NewRemote"));
+    }
+
+    [TestMethod]
+    public void InitialStrings_AreEnumeratedOnceToKeepBothDirectionsConsistent()
+    {
+        int enumerationCount = 0;
+        IEnumerable<string> GetInitialStrings()
+        {
+            enumerationCount++;
+            yield return "Known";
+        }
+
+        var m = new PooledStringManager(GetInitialStrings());
+
+        Assert.AreEqual(1, enumerationCount);
+        Assert.IsTrue(m.GetOrCreateID("Known", out int id));
+        Assert.AreEqual(1, id);
+        Assert.AreEqual("Known", m.GetAndRecord(1, null));
+    }
+
+    [DataRow(0)]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    [TestMethod]
+    public void GetAndRecord_RejectsNonPositiveID(int id)
+    {
+        var m = new PooledStringManager([]);
+
+        Assert.Throws<InvalidDataException>(() => m.GetAndRecord(id, "invalid"));
+    }
+
+    [TestMethod]
+    public void GetAndRecord_RejectsSparseNewIDsWithoutAdvancingSequence()
+    {
+        var m = new PooledStringManager([]);
+
+        Assert.Throws<InvalidDataException>(() => m.GetAndRecord(2, "sparse"));
+        Assert.AreEqual("first", m.GetAndRecord(1, "first"));
+        Assert.Throws<InvalidDataException>(() => m.GetAndRecord(3, "still-sparse"));
+        Assert.AreEqual("second", m.GetAndRecord(2, "second"));
+    }
+
+    [TestMethod]
+    public void GetAndRecord_RepeatedKnownAndLearnedIDsRemainCompatible()
+    {
+        var m = new PooledStringManager(["Known"]);
+
+        Assert.AreEqual("Known", m.GetAndRecord(1, null));
+        Assert.AreEqual("Known", m.GetAndRecord(1, "Known"));
+        Assert.AreEqual("Dynamic", m.GetAndRecord(2, "Dynamic"));
+        Assert.AreEqual("Dynamic", m.GetAndRecord(2, null));
+        Assert.AreEqual("Dynamic", m.GetAndRecord(2, "Dynamic"));
+    }
+
+    [TestMethod]
     public void EndToEnd_PooledString_SerializeDeserialize_RoundTrip()
     {
         // sender and receiver have independent managers (empty initial)
@@ -111,19 +178,65 @@ public class PooledStringManagerTests
             Assert.AreEqual("", (string)s);
         }
 
-        // near 65535 UTF-8 bytes string (exact 65535 bytes)
-        int len = 65535; // RefBinaryWriter encodes length as ushort
-        string big = new string('A', len);
-        Assert.AreEqual(len, Encoding.UTF8.GetByteCount(big));
+        string boundary = new string('A', PooledStringManager.MaxRemoteStringUtf8Bytes);
+        Assert.AreEqual(PooledStringManager.MaxRemoteStringUtf8Bytes, Encoding.UTF8.GetByteCount(boundary));
 
         using (var ms = new MemoryStream())
         {
             var w = new RefBinaryWriter(ms);
-            w.Write(new PooledString(big), sender);
+            w.Write(new PooledString(boundary), sender);
             var r = new RefBinaryReader(ms.ToArray());
             var s = PooledString.Deserialize(ref r, receiver);
-            Assert.AreEqual(big, (string)s);
+            Assert.AreEqual(boundary, (string)s);
         }
+    }
+
+    [TestMethod]
+    public void GetAndRecord_RejectsValueAboveUtf8LimitWithoutConsumingID()
+    {
+        var m = new PooledStringManager([]);
+        string tooLarge = new string('猫', PooledStringManager.MaxRemoteStringUtf8Bytes / 3 + 1);
+        Assert.IsGreaterThan(
+            PooledStringManager.MaxRemoteStringUtf8Bytes,
+            Encoding.UTF8.GetByteCount(tooLarge)
+        );
+
+        Assert.Throws<InvalidDataException>(() => m.GetAndRecord(1, tooLarge));
+        Assert.AreEqual("valid", m.GetAndRecord(1, "valid"));
+    }
+
+    [TestMethod]
+    public void GetAndRecord_EnforcesRemoteEntryLimit()
+    {
+        var m = new PooledStringManager([]);
+        for (int id = 1; id <= PooledStringManager.MaxRemoteEntries; id++)
+            Assert.AreEqual(string.Empty, m.GetAndRecord(id, string.Empty));
+
+        Assert.Throws<InvalidDataException>(() =>
+            m.GetAndRecord(PooledStringManager.MaxRemoteEntries + 1, string.Empty)
+        );
+    }
+
+    [TestMethod]
+    public void GetAndRecord_EnforcesTotalUtf8LimitWithoutConsumingID()
+    {
+        var m = new PooledStringManager([]);
+        int entries = PooledStringManager.MaxRemoteTotalUtf8Bytes
+            / PooledStringManager.MaxRemoteStringUtf8Bytes;
+        for (int i = 0; i < entries; i++)
+        {
+            string prefix = i.ToString("D4", CultureInfo.InvariantCulture);
+            string value = prefix + new string(
+                'A',
+                PooledStringManager.MaxRemoteStringUtf8Bytes - prefix.Length
+            );
+            Assert.AreEqual(PooledStringManager.MaxRemoteStringUtf8Bytes, Encoding.UTF8.GetByteCount(value));
+            Assert.AreEqual(value, m.GetAndRecord(i + 1, value));
+        }
+
+        int nextID = entries + 1;
+        Assert.Throws<InvalidDataException>(() => m.GetAndRecord(nextID, "x"));
+        Assert.AreEqual(string.Empty, m.GetAndRecord(nextID, string.Empty));
     }
 
     [TestMethod]
@@ -197,7 +310,7 @@ public class PooledStringManagerTests
             tasks[i] = Task.Run(() =>
             {
                 start.Wait(TestContext.CancellationToken);
-                string s = m.GetAndRecord(42, "Jump");
+                string s = m.GetAndRecord(1, "Jump");
                 outputs.Add(s);
             }, TestContext.CancellationToken);
         }
@@ -220,12 +333,12 @@ public class PooledStringManagerTests
         var t1 = Task.Run(() =>
         {
             start.Wait(TestContext.CancellationToken);
-            try { r1 = m.GetAndRecord(7, "A"); } catch (Exception ex) { e1 = ex; }
+            try { r1 = m.GetAndRecord(1, "A"); } catch (Exception ex) { e1 = ex; }
         }, TestContext.CancellationToken);
         var t2 = Task.Run(() =>
         {
             start.Wait(TestContext.CancellationToken);
-            try { r2 = m.GetAndRecord(7, "B"); } catch (Exception ex) { e2 = ex; }
+            try { r2 = m.GetAndRecord(1, "B"); } catch (Exception ex) { e2 = ex; }
         }, TestContext.CancellationToken);
 
         start.Set();
@@ -238,7 +351,7 @@ public class PooledStringManagerTests
         Assert.AreEqual(1, failures);
 
         // The winner's value becomes the mapping
-        string mapped = m.GetAndRecord(7, null);
+        string mapped = m.GetAndRecord(1, null);
         Assert.IsTrue(mapped is "A" or "B");
     }
 
@@ -248,9 +361,19 @@ public class PooledStringManagerTests
         var sender = new PooledStringManager(Enumerable.Empty<string>());
         var receiver = new PooledStringManager(Enumerable.Empty<string>());
 
-        // prepare payloads serially from sender (single-threaded send simulation)
+        // Learn new IDs in wire order, as the single receive loop does in production.
         var values = Enumerable.Range(0, 200).Select(i => new PooledString($"Str_{i:D4}")).ToArray();
         var payloads = new byte[values.Length][];
+        for (int i = 0; i < values.Length; i++)
+        {
+            using var ms = new MemoryStream();
+            var w = new RefBinaryWriter(ms);
+            w.Write(values[i], sender);
+            var r = new RefBinaryReader(ms.ToArray());
+            Assert.AreEqual(values[i].Value, (string)PooledString.Deserialize(ref r, receiver));
+        }
+
+        // References to IDs already learned are safe to resolve concurrently and out of order.
         for (int i = 0; i < values.Length; i++)
         {
             using var ms = new MemoryStream();


### PR DESCRIPTION
## 问题

每个连接都会维护一个池化字符串表，用整数 ID 代替后续数据包中重复出现的字符串。

当前实现会接受远端提供的任意新 ID 和字符串，并将其永久保存在当前连接的字符串表中，但没有限制：

- 新 ID 是否连续；
- 动态字符串条目数量；
- 单个字符串的 UTF-8 大小；
- 所有远端字符串的累计大小。

已连接客户端可以持续发送带有新 ID 的 animation、sprite、sound 等字符串，使服务端不断扩展对应连接的字符串表。

这会导致持续的内存增长，同时增加 `ImmutableDictionary` 更新产生的 CPU 和分配压力。

## 原因

本地字符串 ID 按顺序生成，但远端字符串学习路径没有执行相同的顺序约束。

对于一个尚未记录的 ID，原实现只检查是否同时提供了字符串值，然后直接加入字典。远端因此可以：

- 使用零或负数 ID；
- 使用任意稀疏 ID；
- 无限创建新的动态字符串；
- 提交接近单包上限的大字符串；
- 在连接生命周期内持续累积字符串数据。

实际协议发送和接收都是有序处理的，合法实现生成的新动态 ID 也始终连续，因此可以在不影响正常客户端的前提下验证远端 ID 顺序。

## 修改

- 要求远端字符串 ID 必须为正数。
- 要求未知的新 ID 必须等于当前期望的下一个远端 ID。
- 本地和远端 ID 从共享的初始字符串数量之后开始，但分别独立推进。
- 为每个连接增加以下远端动态字符串配额：
  - 最多 4096 个条目；
  - 单个字符串最多 1024 UTF-8 字节；
  - 所有远端动态字符串累计最多 1 MiB。
- 内置的初始已知字符串不占用远端动态配额。
- 已知 ID 和已经学习的动态 ID 仍可正常重复引用。
- 已存在 ID 再次携带相同字符串时保持兼容。
- 已存在 ID 携带不同字符串时继续按原有逻辑拒绝。
- 所有远端协议违规统一抛出 `InvalidDataException`。
- 所有校验都在修改字典、计数和下一个期望 ID 之前完成；失败不会污染连接状态。
- 初始化时将 `initialStrings` 一次性物化，避免多次枚举导致字典和起始计数不一致。

## 兼容性

符合现有发送逻辑的客户端不会受到影响：

- 新动态字符串 ID 原本就是按顺序生成的；
- 已知字符串仍可只发送 ID；
- 已学习的动态字符串仍可只发送 ID；
- 重复携带相同值仍然有效。

以下此前被接受的输入现在会被拒绝：

- 零或负数 ID；
- 稀疏、跳跃或乱序的新 ID；
- 超过 4096 个远端动态字符串；
- 单值超过 1024 UTF-8 字节；
- 累计超过 1 MiB 的远端动态字符串。

接收路径已经会在协议反序列化异常时关闭对应连接，因此违规只影响发送该数据的客户端。

## 验证

扩展 `PooledStringManager` 测试，覆盖：

- 本地与远端从初始字符串数量后的正确 ID 开始；
- 初始字符串枚举只执行一次；
- 零、负数和最小整数 ID 被拒绝；
- 稀疏和乱序的新 ID 被拒绝；
- 已知 ID 可以重复引用；
- 已学习的动态 ID 可以重复引用；
- 重复 ID 携带相同值保持有效；
- 单字符串 1024 UTF-8 字节边界；
- 多字节 UTF-8 字符串超限；
- 4096 个条目边界；
- 1 MiB 累计字节边界；
- 校验失败后不消费 ID；
- 校验失败后不增加累计字节；
- 已学习条目的并发读取；
- 同一已存在 ID 的并发解析。

验证结果：

- 完整单元测试通过：100/100；
- 完整 Debug 解决方案构建通过：
  - 0 个警告；
  - 0 个错误；
- `git diff --check` 通过。
