### PR TITLE
fix(protocol): 修复数据帧边界与 EOF 处理

### DIFF
--- a/source/MiaoNet.ClientShared/MiaoServerConnection.cs
+++ b/source/MiaoNet.ClientShared/MiaoServerConnection.cs
@@ -34,7 +34,6 @@ public sealed partial class MiaoServerConnection : IDisposable
         this.sslStream = sslStream;
 
         sendMemoryStream = new(512);
-        sendMemoryStream.Seek(2, SeekOrigin.Begin);
 
         sendQueue = new();
         sendSemaphore = new(0);
@@ -226,47 +225,15 @@ public sealed partial class MiaoServerConnection : IDisposable
         [EnumeratorCancellation] CancellationToken token
     )
     {
-        const int HeadSize = 2 * sizeof(ushort);
-        byte[] headBuffer = new byte[HeadSize];
+        byte[] headerBuffer = new byte[Connection.PacketHeaderSize];
         while (!token.IsCancellationRequested)
         {
-            IContextualPacket? packet;
-
-            // read head
-            ushort size, type;
-            {
-                int count = await sslStream.ReadAtLeastAsync(headBuffer, HeadSize, false, token);
-                if (count < HeadSize)
-                    packet = null;
-
-                size = BinaryPrimitives.ReadUInt16LittleEndian(headBuffer);
-                type = BinaryPrimitives.ReadUInt16LittleEndian(headBuffer.AsSpan().Slice(sizeof(ushort)));
-            }
-
-            // read payload
-            var payloadBuffer = pool.Rent(size);
-            try
-            {
-                Memory<byte> payloadMemory = payloadBuffer.AsMemory().Slice(0, size);
-                int count = await sslStream.ReadAtLeastAsync(payloadMemory, size, false, token);
-                if (count < size)
-                    packet = null;
-
-                try
-                {
-                    RefBinaryReader reader = new(payloadMemory.Span);
-                    var readHandler = PacketRegistry.GetPacketReader(type);
-                    packet = readHandler(ref reader, context);
-                }
-                catch (Exception e)
-                {
-                    throw new InvalidPacketDataException(payloadMemory.ToArray(), e);
-                }
-            }
-            finally
-            {
-                pool.Return(payloadBuffer);
-            }
+            IContextualPacket? packet = await PacketFraming.ReadPacketAsync(
+                sslStream,
+                headerBuffer,
+                context,
+                token
+            );
 
             if (packet is null)
                 yield break;
@@ -285,14 +252,9 @@ public sealed partial class MiaoServerConnection : IDisposable
 
     private async Task SendPacketAsync(IContextualPacket packet, IPacketSerializationContext context, CancellationToken token)
     {
-        sendMemoryStream.Seek(2, SeekOrigin.Begin);
-        RefBinaryWriter writer = new(sendMemoryStream);
-        ushort type = PacketRegistry.GetPacketID(packet);
-        writer.Write(type);
-        packet.Serialize(ref writer, context);
-        ushort length = (ushort)(sendMemoryStream.Position - 2 * sizeof(ushort));
-        sendMemoryStream.Seek(0, SeekOrigin.Begin);
-        writer.Write(length);
-        await sslStream.WriteAsync(sendMemoryStream.GetBuffer().AsMemory(0, length + 2 * sizeof(ushort)), token);
+        sendMemoryStream.Position = 0;
+        PacketFraming.WritePacket(sendMemoryStream, packet, context);
+        int frameSize = checked((int)sendMemoryStream.Position);
+        await sslStream.WriteAsync(sendMemoryStream.GetBuffer().AsMemory(0, frameSize), token);
     }
 }

--- a/source/MiaoNet.Server/AssemblyInfo.cs
+++ b/source/MiaoNet.Server/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [module: SkipLocalsInit]
+[assembly: InternalsVisibleTo("MiaoNet.UnitTest")]

--- a/source/MiaoNet.Server/Server/MiaoClientConnection.cs
+++ b/source/MiaoNet.Server/Server/MiaoClientConnection.cs
@@ -178,7 +178,7 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
 
     private async Task HandleClientProcessingAsync(CancellationToken token)
     {
-        await ProcessPacketsAsync(
+        long leftoverBytes = await ProcessPacketsAsync(
             pipe.Reader,
             this,
             async (packet, bytesConsumed) =>
@@ -188,10 +188,19 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
             },
             token
         );
+        if (leftoverBytes > 0)
+        {
+            logger.LogWarning(
+                AppEvents.Connection,
+                "Connection id {id} closed with {leftover} leftover bytes that do not form a complete packet frame.",
+                ID,
+                leftoverBytes
+            );
+        }
         logger.LogDebug("Processing task of id {id} finished.", ID);
     }
 
-    internal static async Task ProcessPacketsAsync(
+    internal static async Task<long> ProcessPacketsAsync(
         PipeReader pipeReader,
         IPacketSerializationContext context,
         Func<IContextualPacket, int, ValueTask> packetHandler,
@@ -200,10 +209,10 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
     {
         try
         {
+            long leftoverBytes = 0;
             while (true)
             {
                 ReadResult result = await pipeReader.ReadAsync(token);
-                ReadOnlySequence<byte> oldBuffer = result.Buffer;
                 ReadOnlySequence<byte> buffer = result.Buffer;
                 while (true)
                 {
@@ -214,10 +223,15 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
                     await packetHandler(packet, bytesConsumed);
                 }
 
+                long leftover = buffer.Length;
                 pipeReader.AdvanceTo(buffer.Start, buffer.End);
                 if (result.IsCompleted)
+                {
+                    leftoverBytes = leftover;
                     break;
+                }
             }
+            return leftoverBytes;
         }
         finally
         {
@@ -246,7 +260,7 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
         logger.LogDebug("Sending task of id {id} finished.", ID);
     }
 
-    private static bool TryParsePacket(
+    internal static bool TryParsePacket(
         ref ReadOnlySequence<byte> sequence,
         [NotNullWhen(true)] out IContextualPacket? packet,
         IPacketSerializationContext context

--- a/source/MiaoNet.Server/Server/MiaoClientConnection.cs
+++ b/source/MiaoNet.Server/Server/MiaoClientConnection.cs
@@ -178,30 +178,51 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
 
     private async Task HandleClientProcessingAsync(CancellationToken token)
     {
-        var pipeReader = pipe.Reader;
-        while (true)
-        {
-            var result = await pipeReader.ReadAsync(token);
-            if (result.IsCompleted)
-                break;
-
-            var oldBuffer = result.Buffer;
-            var buffer = result.Buffer;
-            while (TryParsePacket(ref buffer, out IContextualPacket? packet, this))
+        await ProcessPacketsAsync(
+            pipe.Reader,
+            this,
+            async (packet, bytesConsumed) =>
             {
-                metricsService.RecordPacketTcpDownload((int)(oldBuffer.Length - buffer.Length));
+                metricsService.RecordPacketTcpDownload(bytesConsumed);
                 await server.HandlePacketAsync(this, packet);
-            }
+            },
+            token
+        );
+        logger.LogDebug("Processing task of id {id} finished.", ID);
+    }
 
-            pipeReader.AdvanceTo(buffer.Start, buffer.End);
-            if (result.IsCompleted)
+    internal static async Task ProcessPacketsAsync(
+        PipeReader pipeReader,
+        IPacketSerializationContext context,
+        Func<IContextualPacket, int, ValueTask> packetHandler,
+        CancellationToken token
+    )
+    {
+        try
+        {
+            while (true)
             {
-                await pipeReader.CompleteAsync();
-                break;
+                ReadResult result = await pipeReader.ReadAsync(token);
+                ReadOnlySequence<byte> oldBuffer = result.Buffer;
+                ReadOnlySequence<byte> buffer = result.Buffer;
+                while (true)
+                {
+                    long lengthBeforePacket = buffer.Length;
+                    if (!TryParsePacket(ref buffer, out IContextualPacket? packet, context))
+                        break;
+                    int bytesConsumed = checked((int)(lengthBeforePacket - buffer.Length));
+                    await packetHandler(packet, bytesConsumed);
+                }
+
+                pipeReader.AdvanceTo(buffer.Start, buffer.End);
+                if (result.IsCompleted)
+                    break;
             }
         }
-        await pipeReader.CompleteAsync();
-        logger.LogDebug("Processing task of id {id} finished.", ID);
+        finally
+        {
+            await pipeReader.CompleteAsync();
+        }
     }
 
     private async Task HandleClientSendingAsync(CancellationToken token)
@@ -249,15 +270,25 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
             return false;
         }
 
-        Span<byte> payloadSpan = stackalloc byte[size];
+        byte[]? rented = null;
+        Span<byte> payloadSpan = size <= 1024
+            ? stackalloc byte[size]
+            : (rented = ArrayPool<byte>.Shared.Rent(size)).AsSpan(0, size);
+        try
+        {
+            payloadSequence.Slice(0, size).CopyTo(payloadSpan);
+            sequence = payloadSequence.Slice(size);
 
-        payloadSequence.Slice(0, size).CopyTo(payloadSpan);
-        sequence = payloadSequence.Slice(size);
-
-        RefBinaryReader reader = new(payloadSpan);
-        var readHandler = PacketRegistry.GetPacketReader(id);
-        packet = readHandler(ref reader, context);
-        return true;
+            RefBinaryReader reader = new(payloadSpan);
+            var readHandler = PacketRegistry.GetPacketReader(id);
+            packet = readHandler(ref reader, context);
+            return true;
+        }
+        finally
+        {
+            if (rented is not null)
+                ArrayPool<byte>.Shared.Return(rented);
+        }
     }
 
     private static void WritePacket(
@@ -265,16 +296,5 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
         IContextualPacket packet,
         IPacketSerializationContext context
     )
-    {
-        stream.Seek(sizeof(ushort) + sizeof(ushort), SeekOrigin.Current);
-        long start = stream.Position;
-        RefBinaryWriter w = new(stream);
-        packet.Serialize(ref w, context);
-        ushort size = checked((ushort)(stream.Position - start));
-        ushort id = PacketRegistry.GetPacketID(packet);
-        stream.Seek(-size - sizeof(ushort) - sizeof(ushort), SeekOrigin.Current);
-        w.Write(size);
-        w.Write(id);
-        stream.Seek(size, SeekOrigin.Current);
-    }
+        => PacketFraming.WritePacket(stream, packet, context);
 }

--- a/source/MiaoNet.Shared/Connection/Connection.cs
+++ b/source/MiaoNet.Shared/Connection/Connection.cs
@@ -13,6 +13,10 @@ public static class Connection
 
     public const int HandshakeHeadLength = 16;
 
+    public const int PacketHeaderSize = sizeof(ushort) * 2;
+
+    public const int MaxPayloadSize = ushort.MaxValue;
+
     // allows only TLS 1.2 or TLS 1.3
     public const SslProtocols AllowedSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13;
 

--- a/source/MiaoNet.Shared/Connection/InvalidPacketDataException.cs
+++ b/source/MiaoNet.Shared/Connection/InvalidPacketDataException.cs
@@ -1,4 +1,4 @@
-namespace MiaoNet.ClientShared;
+namespace MiaoNet.Shared;
 
 internal sealed class InvalidPacketDataException : Exception
 {

--- a/source/MiaoNet.Shared/Connection/PacketFraming.cs
+++ b/source/MiaoNet.Shared/Connection/PacketFraming.cs
@@ -1,0 +1,118 @@
+using System.Buffers;
+using System.Buffers.Binary;
+
+namespace MiaoNet.Shared;
+
+public static class PacketFraming
+{
+    private static readonly ArrayPool<byte> pool = ArrayPool<byte>.Shared;
+
+    public static void WritePacket(
+        Stream stream,
+        IContextualPacket packet,
+        IPacketSerializationContext context
+    )
+    {
+        ushort packetID = PacketRegistry.GetPacketID(packet);
+        long frameStart = stream.Position;
+        stream.Seek(Connection.PacketHeaderSize, SeekOrigin.Current);
+        long payloadStart = stream.Position;
+
+        RefBinaryWriter writer = new(stream);
+        packet.Serialize(ref writer, context);
+
+        long payloadSize = stream.Position - payloadStart;
+        if (payloadSize > Connection.MaxPayloadSize)
+        {
+            throw new PacketTooLargeException(
+                packet.GetType(),
+                payloadSize,
+                Connection.MaxPayloadSize
+            );
+        }
+
+        long frameEnd = stream.Position;
+        stream.Position = frameStart;
+        writer.Write((ushort)payloadSize);
+        writer.Write(packetID);
+        stream.Position = frameEnd;
+    }
+
+    public static async ValueTask<IContextualPacket?> ReadPacketAsync(
+        Stream stream,
+        IPacketSerializationContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        byte[] headerBuffer = pool.Rent(Connection.PacketHeaderSize);
+        try
+        {
+            return await ReadPacketAsync(
+                stream,
+                headerBuffer.AsMemory(0, Connection.PacketHeaderSize),
+                context,
+                cancellationToken
+            );
+        }
+        finally
+        {
+            pool.Return(headerBuffer);
+        }
+    }
+
+    internal static async ValueTask<IContextualPacket?> ReadPacketAsync(
+        Stream stream,
+        Memory<byte> headerMemory,
+        IPacketSerializationContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        if (headerMemory.Length < Connection.PacketHeaderSize)
+            throw new ArgumentException("The packet header buffer is too small.", nameof(headerMemory));
+
+        headerMemory = headerMemory[..Connection.PacketHeaderSize];
+        int headerBytesRead = await stream.ReadAtLeastAsync(
+            headerMemory,
+            Connection.PacketHeaderSize,
+            throwOnEndOfStream: false,
+            cancellationToken
+        );
+        if (headerBytesRead < Connection.PacketHeaderSize)
+            return null;
+
+        ushort payloadSize = BinaryPrimitives.ReadUInt16LittleEndian(headerMemory.Span);
+        ushort packetID = BinaryPrimitives.ReadUInt16LittleEndian(headerMemory.Span[sizeof(ushort)..]);
+
+        byte[] payloadBuffer = pool.Rent(payloadSize);
+        try
+        {
+            Memory<byte> payloadMemory = payloadBuffer.AsMemory(0, payloadSize);
+            if (payloadSize > 0)
+            {
+                int payloadBytesRead = await stream.ReadAtLeastAsync(
+                    payloadMemory,
+                    payloadSize,
+                    throwOnEndOfStream: false,
+                    cancellationToken
+                );
+                if (payloadBytesRead < payloadSize)
+                    return null;
+            }
+
+            try
+            {
+                RefBinaryReader reader = new(payloadMemory.Span);
+                RefBinaryPacketReadHandler readHandler = PacketRegistry.GetPacketReader(packetID);
+                return readHandler(ref reader, context);
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidPacketDataException(payloadMemory.ToArray(), exception);
+            }
+        }
+        finally
+        {
+            pool.Return(payloadBuffer);
+        }
+    }
+}

--- a/source/MiaoNet.Shared/Connection/PacketFraming.cs
+++ b/source/MiaoNet.Shared/Connection/PacketFraming.cs
@@ -78,7 +78,11 @@ public static class PacketFraming
             cancellationToken
         );
         if (headerBytesRead < Connection.PacketHeaderSize)
+        {
+            if (headerBytesRead > 0)
+                throw new PacketTruncatedException(isPayload: false, headerBytesRead, Connection.PacketHeaderSize);
             return null;
+        }
 
         ushort payloadSize = BinaryPrimitives.ReadUInt16LittleEndian(headerMemory.Span);
         ushort packetID = BinaryPrimitives.ReadUInt16LittleEndian(headerMemory.Span[sizeof(ushort)..]);
@@ -96,7 +100,7 @@ public static class PacketFraming
                     cancellationToken
                 );
                 if (payloadBytesRead < payloadSize)
-                    return null;
+                    throw new PacketTruncatedException(isPayload: true, payloadBytesRead, payloadSize);
             }
 
             try

--- a/source/MiaoNet.Shared/Connection/PacketFraming.cs
+++ b/source/MiaoNet.Shared/Connection/PacketFraming.cs
@@ -68,7 +68,7 @@ public static class PacketFraming
     )
     {
         if (headerMemory.Length < Connection.PacketHeaderSize)
-            throw new ArgumentException("The packet header buffer is too small.", nameof(headerMemory));
+            throw new ArgumentException(SR.PacketHeaderBufferTooSmall, nameof(headerMemory));
 
         headerMemory = headerMemory[..Connection.PacketHeaderSize];
         int headerBytesRead = await stream.ReadAtLeastAsync(

--- a/source/MiaoNet.Shared/Connection/PacketTooLargeException.cs
+++ b/source/MiaoNet.Shared/Connection/PacketTooLargeException.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+
+namespace MiaoNet.Shared;
+
+public sealed class PacketTooLargeException : Exception
+{
+    public Type PacketType { get; }
+
+    public long PayloadSize { get; }
+
+    public int MaxPayloadSize { get; }
+
+    public PacketTooLargeException(Type packetType, long payloadSize, int maxPayloadSize)
+        : base(string.Format(
+            CultureInfo.InvariantCulture,
+            SR.PacketTooLarge,
+            packetType.FullName,
+            payloadSize,
+            maxPayloadSize
+        ))
+    {
+        PacketType = packetType;
+        PayloadSize = payloadSize;
+        MaxPayloadSize = maxPayloadSize;
+    }
+}

--- a/source/MiaoNet.Shared/Connection/PacketTruncatedException.cs
+++ b/source/MiaoNet.Shared/Connection/PacketTruncatedException.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+
+namespace MiaoNet.Shared;
+
+public sealed class PacketTruncatedException : Exception
+{
+    public bool IsPayload { get; }
+
+    public int BytesRead { get; }
+
+    public int ExpectedBytes { get; }
+
+    public PacketTruncatedException(bool isPayload, int bytesRead, int expectedBytes)
+        : base(string.Format(
+            CultureInfo.InvariantCulture,
+            SR.PacketTruncated,
+            isPayload ? "payload" : "header",
+            bytesRead,
+            expectedBytes
+        ))
+    {
+        IsPayload = isPayload;
+        BytesRead = bytesRead;
+        ExpectedBytes = expectedBytes;
+    }
+}

--- a/source/MiaoNet.Shared/Connection/PacketTruncatedException.cs
+++ b/source/MiaoNet.Shared/Connection/PacketTruncatedException.cs
@@ -14,7 +14,7 @@ public sealed class PacketTruncatedException : Exception
         : base(string.Format(
             CultureInfo.InvariantCulture,
             SR.PacketTruncated,
-            isPayload ? "payload" : "header",
+            isPayload ? SR.PacketPartPayload : SR.PacketPartHeader,
             bytesRead,
             expectedBytes
         ))

--- a/source/MiaoNet.Shared/SR.cs
+++ b/source/MiaoNet.Shared/SR.cs
@@ -13,7 +13,7 @@ internal static class SR
     public const string PacketNotFoundByID
         = "Packet type with id {0} is not found.";
     public const string PacketTooLarge
-        = "Packet \"{0}\" is too large with size {1}.";
+        = "Packet \"{0}\" is too large with payload size {1}; the maximum is {2}.";
     public const string PacketHasDataLeft
         = "Packet id {0} read finished but left {1} bytes not read.";
     public const string HasDataLeft

--- a/source/MiaoNet.Shared/SR.cs
+++ b/source/MiaoNet.Shared/SR.cs
@@ -16,6 +16,12 @@ internal static class SR
         = "Packet \"{0}\" is too large with payload size {1}; the maximum is {2}.";
     public const string PacketTruncated
         = "Packet {0} is truncated: read {1} of {2} bytes.";
+    public const string PacketHeaderBufferTooSmall
+        = "The packet header buffer is too small.";
+    public const string PacketPartHeader
+        = "header";
+    public const string PacketPartPayload
+        = "payload";
     public const string PacketHasDataLeft
         = "Packet id {0} read finished but left {1} bytes not read.";
     public const string HasDataLeft

--- a/source/MiaoNet.Shared/SR.cs
+++ b/source/MiaoNet.Shared/SR.cs
@@ -14,6 +14,8 @@ internal static class SR
         = "Packet type with id {0} is not found.";
     public const string PacketTooLarge
         = "Packet \"{0}\" is too large with payload size {1}; the maximum is {2}.";
+    public const string PacketTruncated
+        = "Packet {0} is truncated: read {1} of {2} bytes.";
     public const string PacketHasDataLeft
         = "Packet id {0} read finished but left {1} bytes not read.";
     public const string HasDataLeft

--- a/source/MiaoNet.UnitTest/PacketFramingTests.cs
+++ b/source/MiaoNet.UnitTest/PacketFramingTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.IO.Pipelines;
 using MiaoNet.Server;
@@ -58,22 +59,22 @@ public sealed class PacketFramingTests
     }
 
     [TestMethod]
-    public async Task ReadPacketReturnsNullForPartialHeader()
+    public async Task ReadPacketThrowsOnTruncatedHeader()
     {
         byte[] frame = WriteFrame(new PacketPing());
         using var stream = new MemoryStream(frame, 0, Connection.PacketHeaderSize - 1);
 
-        IContextualPacket? packet = await PacketFraming.ReadPacketAsync(
-            stream,
-            context,
-            CancellationToken.None
+        PacketTruncatedException exception = await Assert.ThrowsExactlyAsync<PacketTruncatedException>(
+            () => PacketFraming.ReadPacketAsync(stream, context, CancellationToken.None).AsTask()
         );
 
-        Assert.IsNull(packet);
+        Assert.IsFalse(exception.IsPayload);
+        Assert.AreEqual(Connection.PacketHeaderSize - 1, exception.BytesRead);
+        Assert.AreEqual(Connection.PacketHeaderSize, exception.ExpectedBytes);
     }
 
     [TestMethod]
-    public async Task ReadPacketReturnsNullAtFrameBoundaryEof()
+    public async Task ReadPacketReturnsNullAtCleanEof()
     {
         using var stream = new MemoryStream();
 
@@ -87,18 +88,18 @@ public sealed class PacketFramingTests
     }
 
     [TestMethod]
-    public async Task ReadPacketReturnsNullForPartialPayload()
+    public async Task ReadPacketThrowsOnTruncatedPayload()
     {
         byte[] frame = WriteFrame(new PacketPing());
         using var stream = new MemoryStream(frame, 0, frame.Length - 1);
 
-        IContextualPacket? packet = await PacketFraming.ReadPacketAsync(
-            stream,
-            context,
-            CancellationToken.None
+        PacketTruncatedException exception = await Assert.ThrowsExactlyAsync<PacketTruncatedException>(
+            () => PacketFraming.ReadPacketAsync(stream, context, CancellationToken.None).AsTask()
         );
 
-        Assert.IsNull(packet);
+        Assert.IsTrue(exception.IsPayload);
+        Assert.AreEqual(frame.Length - Connection.PacketHeaderSize - 1, exception.BytesRead);
+        Assert.AreEqual(exception.ExpectedBytes, frame.Length - Connection.PacketHeaderSize);
     }
 
     [TestMethod]
@@ -122,6 +123,51 @@ public sealed class PacketFramingTests
     }
 
     [TestMethod]
+    public async Task ReadPacketParsesMultipleFramesSequentially()
+    {
+        byte[] frameA = WriteFrame(new PacketPing());
+        byte[] frameB = WriteFrame(new PacketPong());
+        byte[] frameC = WriteFrame(new PacketSendChatMessage(default, "hello"));
+        byte[] all = new byte[frameA.Length + frameB.Length + frameC.Length];
+        frameA.CopyTo(all, 0);
+        frameB.CopyTo(all, frameA.Length);
+        frameC.CopyTo(all, frameA.Length + frameB.Length);
+        using var stream = new MemoryStream(all);
+
+        IContextualPacket? packet1 = await PacketFraming.ReadPacketAsync(stream, context, CancellationToken.None);
+        IContextualPacket? packet2 = await PacketFraming.ReadPacketAsync(stream, context, CancellationToken.None);
+        IContextualPacket? packet3 = await PacketFraming.ReadPacketAsync(stream, context, CancellationToken.None);
+        IContextualPacket? packet4 = await PacketFraming.ReadPacketAsync(stream, context, CancellationToken.None);
+
+        Assert.IsInstanceOfType<PacketPing>(packet1);
+        Assert.IsInstanceOfType<PacketPong>(packet2);
+        Assert.IsInstanceOfType<PacketSendChatMessage>(packet3);
+        Assert.IsNull(packet4);
+    }
+
+    [TestMethod]
+    public async Task ReadPacketWrapsDeserializationFailureInInvalidPacketDataException()
+    {
+        byte[] payload = { 0 }; // 只有 ChatChannel 字段,缺少字符串长度与内容
+        byte[] frame = new byte[Connection.PacketHeaderSize + payload.Length];
+        BinaryPrimitives.WriteUInt16LittleEndian(frame, (ushort)payload.Length);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            frame.AsSpan(sizeof(ushort)),
+            PacketRegistry.GetPacketID(new PacketSendChatMessage(default, string.Empty))
+        );
+        payload.CopyTo(frame.AsSpan(Connection.PacketHeaderSize));
+        using var stream = new MemoryStream(frame);
+
+        InvalidPacketDataException exception = await Assert.ThrowsExactlyAsync<InvalidPacketDataException>(
+            () => PacketFraming.ReadPacketAsync(stream, context, CancellationToken.None).AsTask()
+        );
+
+        Assert.HasCount(1, exception.Payload);
+        Assert.AreEqual((byte)0, exception.Payload[0]);
+        Assert.IsNotNull(exception.InnerException);
+    }
+
+    [TestMethod]
     public async Task CompletedPipeStillProcessesItsFinalBufferedPacket()
     {
         byte[] frame = WriteFrame(new PacketPing());
@@ -130,7 +176,7 @@ public sealed class PacketFramingTests
         await pipe.Writer.CompleteAsync();
         var receivedPackets = new List<IContextualPacket>();
 
-        await MiaoClientConnection.ProcessPacketsAsync(
+        long leftover = await MiaoClientConnection.ProcessPacketsAsync(
             pipe.Reader,
             context,
             (packet, _) =>
@@ -143,6 +189,7 @@ public sealed class PacketFramingTests
 
         Assert.HasCount(1, receivedPackets);
         Assert.IsInstanceOfType<PacketPing>(receivedPackets[0]);
+        Assert.AreEqual(0L, leftover);
     }
 
     [TestMethod]
@@ -161,7 +208,7 @@ public sealed class PacketFramingTests
         await pipe.Writer.CompleteAsync();
         int received = 0;
 
-        await MiaoClientConnection.ProcessPacketsAsync(
+        long leftover = await MiaoClientConnection.ProcessPacketsAsync(
             pipe.Reader,
             context,
             (packet, bytesConsumed) =>
@@ -175,6 +222,102 @@ public sealed class PacketFramingTests
         );
 
         Assert.AreEqual(1, received);
+        Assert.AreEqual(0L, leftover);
+    }
+
+    [TestMethod]
+    public async Task CompletedPipeReturnsLeftoverBytesForPartialFrame()
+    {
+        byte[] frame = WriteFrame(new PacketPing());
+        var pipe = new Pipe();
+        await pipe.Writer.WriteAsync(frame.AsMemory(0, frame.Length - 2));
+        await pipe.Writer.CompleteAsync();
+        var receivedPackets = new List<IContextualPacket>();
+
+        long leftover = await MiaoClientConnection.ProcessPacketsAsync(
+            pipe.Reader,
+            context,
+            (packet, _) =>
+            {
+                receivedPackets.Add(packet);
+                return ValueTask.CompletedTask;
+            },
+            CancellationToken.None
+        );
+
+        Assert.HasCount(0, receivedPackets);
+        Assert.AreEqual(frame.Length - 2, leftover);
+    }
+
+    [TestMethod]
+    public void TryParsePacketParsesSingleFrame()
+    {
+        byte[] frame = WriteFrame(new PacketPing());
+        ReadOnlySequence<byte> sequence = new(frame);
+
+        bool parsed = MiaoClientConnection.TryParsePacket(ref sequence, out var packet, context);
+
+        Assert.IsTrue(parsed);
+        Assert.IsInstanceOfType<PacketPing>(packet);
+        Assert.AreEqual(0L, sequence.Length);
+    }
+
+    [TestMethod]
+    public void TryParsePacketReturnsFalseForIncompleteHeader()
+    {
+        byte[] frame = WriteFrame(new PacketPing());
+        ReadOnlySequence<byte> sequence = new(frame.AsMemory(0, Connection.PacketHeaderSize - 1));
+
+        bool parsed = MiaoClientConnection.TryParsePacket(ref sequence, out var packet, context);
+
+        Assert.IsFalse(parsed);
+        Assert.IsNull(packet);
+    }
+
+    [TestMethod]
+    public void TryParsePacketReturnsFalseForIncompletePayload()
+    {
+        byte[] frame = WriteFrame(new PacketPing());
+        ReadOnlySequence<byte> sequence = new(frame.AsMemory(0, frame.Length - 1));
+
+        bool parsed = MiaoClientConnection.TryParsePacket(ref sequence, out var packet, context);
+
+        Assert.IsFalse(parsed);
+        Assert.IsNull(packet);
+    }
+
+    [TestMethod]
+    public void TryParsePacketParsesMultipleFrames()
+    {
+        byte[] frameA = WriteFrame(new PacketPing());
+        byte[] frameB = WriteFrame(new PacketPong());
+        byte[] all = new byte[frameA.Length + frameB.Length];
+        frameA.CopyTo(all, 0);
+        frameB.CopyTo(all, frameA.Length);
+        ReadOnlySequence<byte> sequence = new(all);
+
+        bool parsed1 = MiaoClientConnection.TryParsePacket(ref sequence, out var packet1, context);
+        Assert.IsTrue(parsed1);
+        Assert.IsInstanceOfType<PacketPing>(packet1);
+
+        bool parsed2 = MiaoClientConnection.TryParsePacket(ref sequence, out var packet2, context);
+        Assert.IsTrue(parsed2);
+        Assert.IsInstanceOfType<PacketPong>(packet2);
+
+        Assert.AreEqual(0L, sequence.Length);
+    }
+
+    [TestMethod]
+    public void TryParsePacketHandlesLargePayloadWithoutStackAllocation()
+    {
+        byte[] frame = WriteFrame(new PacketSendChatMessage(default, new string('a', 5000)));
+        ReadOnlySequence<byte> sequence = new(frame);
+
+        bool parsed = MiaoClientConnection.TryParsePacket(ref sequence, out var packet, context);
+
+        Assert.IsTrue(parsed);
+        Assert.IsInstanceOfType<PacketSendChatMessage>(packet);
+        Assert.AreEqual(0L, sequence.Length);
     }
 
     private byte[] WriteFrame(IContextualPacket packet)

--- a/source/MiaoNet.UnitTest/PacketFramingTests.cs
+++ b/source/MiaoNet.UnitTest/PacketFramingTests.cs
@@ -1,0 +1,191 @@
+using System.Buffers.Binary;
+using System.IO.Pipelines;
+using MiaoNet.Server;
+using MiaoNet.Shared;
+
+namespace MiaoNet.UnitTest;
+
+[TestClass]
+public sealed class PacketFramingTests
+{
+    private readonly TestPacketSerializationContext context = new();
+
+    [TestMethod]
+    public void WritePacketRejectsPayloadLargerThanProtocolLimit()
+    {
+        string largeName = new('a', 33_000);
+        string largePrefix = new('b', 33_000);
+        var packet = new PacketClientInitial(
+            channelID: 1,
+            playerID: 2,
+            new PlayerInfo(3, largeName, largePrefix, string.Empty, Color.White),
+            Array.Empty<PacketClientInitial.Channel>(),
+            Array.Empty<PacketClientInitial.Player>(),
+            new PlayerPresenceMessage(string.Empty, string.Empty),
+            string.Empty
+        );
+        using var stream = new MemoryStream();
+
+        PacketTooLargeException exception = Assert.ThrowsExactly<PacketTooLargeException>(
+            () => PacketFraming.WritePacket(stream, packet, context)
+        );
+
+        Assert.AreEqual(packet.GetType(), exception.PacketType);
+        Assert.IsGreaterThan(Connection.MaxPayloadSize, exception.PayloadSize);
+        Assert.AreEqual(Connection.MaxPayloadSize, exception.MaxPayloadSize);
+    }
+
+    [TestMethod]
+    public void WritePacketAcceptsPayloadAtProtocolLimit()
+    {
+        const int packetFieldsSize = sizeof(byte) + sizeof(ushort);
+        var packet = new PacketSendChatMessage(
+            default,
+            new string('a', Connection.MaxPayloadSize - packetFieldsSize)
+        );
+        using var stream = new MemoryStream();
+
+        PacketFraming.WritePacket(stream, packet, context);
+
+        Assert.AreEqual(
+            Connection.MaxPayloadSize,
+            BinaryPrimitives.ReadUInt16LittleEndian(stream.GetBuffer())
+        );
+        Assert.AreEqual(
+            Connection.PacketHeaderSize + Connection.MaxPayloadSize,
+            stream.Length
+        );
+    }
+
+    [TestMethod]
+    public async Task ReadPacketReturnsNullForPartialHeader()
+    {
+        byte[] frame = WriteFrame(new PacketPing());
+        using var stream = new MemoryStream(frame, 0, Connection.PacketHeaderSize - 1);
+
+        IContextualPacket? packet = await PacketFraming.ReadPacketAsync(
+            stream,
+            context,
+            CancellationToken.None
+        );
+
+        Assert.IsNull(packet);
+    }
+
+    [TestMethod]
+    public async Task ReadPacketReturnsNullAtFrameBoundaryEof()
+    {
+        using var stream = new MemoryStream();
+
+        IContextualPacket? packet = await PacketFraming.ReadPacketAsync(
+            stream,
+            context,
+            CancellationToken.None
+        );
+
+        Assert.IsNull(packet);
+    }
+
+    [TestMethod]
+    public async Task ReadPacketReturnsNullForPartialPayload()
+    {
+        byte[] frame = WriteFrame(new PacketPing());
+        using var stream = new MemoryStream(frame, 0, frame.Length - 1);
+
+        IContextualPacket? packet = await PacketFraming.ReadPacketAsync(
+            stream,
+            context,
+            CancellationToken.None
+        );
+
+        Assert.IsNull(packet);
+    }
+
+    [TestMethod]
+    public async Task ReadPacketPreservesExistingWireFormat()
+    {
+        byte[] frame = WriteFrame(new PacketPing());
+        Assert.AreEqual(sizeof(int), BinaryPrimitives.ReadUInt16LittleEndian(frame));
+        Assert.AreEqual(
+            PacketRegistry.GetPacketID(new PacketPing()),
+            BinaryPrimitives.ReadUInt16LittleEndian(frame.AsSpan(sizeof(ushort)))
+        );
+        using var stream = new MemoryStream(frame);
+
+        IContextualPacket? packet = await PacketFraming.ReadPacketAsync(
+            stream,
+            context,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOfType<PacketPing>(packet);
+    }
+
+    [TestMethod]
+    public async Task CompletedPipeStillProcessesItsFinalBufferedPacket()
+    {
+        byte[] frame = WriteFrame(new PacketPing());
+        var pipe = new Pipe();
+        await pipe.Writer.WriteAsync(frame);
+        await pipe.Writer.CompleteAsync();
+        var receivedPackets = new List<IContextualPacket>();
+
+        await MiaoClientConnection.ProcessPacketsAsync(
+            pipe.Reader,
+            context,
+            (packet, _) =>
+            {
+                receivedPackets.Add(packet);
+                return ValueTask.CompletedTask;
+            },
+            CancellationToken.None
+        );
+
+        Assert.HasCount(1, receivedPackets);
+        Assert.IsInstanceOfType<PacketPing>(receivedPackets[0]);
+    }
+
+    [TestMethod]
+    public async Task CompletedPipeProcessesMaximumPayloadWithoutLargeStackAllocation()
+    {
+        const int packetFieldsSize = sizeof(byte) + sizeof(ushort);
+        byte[] frame = WriteFrame(new PacketSendChatMessage(
+            default,
+            new string('a', Connection.MaxPayloadSize - packetFieldsSize)
+        ));
+        var pipe = new Pipe(new PipeOptions(
+            pauseWriterThreshold: long.MaxValue,
+            resumeWriterThreshold: long.MaxValue - 1
+        ));
+        await pipe.Writer.WriteAsync(frame);
+        await pipe.Writer.CompleteAsync();
+        int received = 0;
+
+        await MiaoClientConnection.ProcessPacketsAsync(
+            pipe.Reader,
+            context,
+            (packet, bytesConsumed) =>
+            {
+                Assert.IsInstanceOfType<PacketSendChatMessage>(packet);
+                Assert.AreEqual(frame.Length, bytesConsumed);
+                received++;
+                return ValueTask.CompletedTask;
+            },
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, received);
+    }
+
+    private byte[] WriteFrame(IContextualPacket packet)
+    {
+        using var stream = new MemoryStream();
+        PacketFraming.WritePacket(stream, packet, context);
+        return stream.ToArray();
+    }
+
+    private sealed class TestPacketSerializationContext : IPacketSerializationContext
+    {
+        public PooledStringManager PooledStringManager { get; } = new(KnownPooledStrings.All);
+    }
+}


### PR DESCRIPTION
## 前置 PR

- 在 #38 后合并；两个 PR 都会修改共享协议资源文本。
- #38 合并后，本分支需要 rebase 到最新 `wip`，保留双方的错误信息和测试，再重新执行完整验证。
- 此项不是运行时依赖，主要用于避免共享文件的合并冲突。

## 问题

客户端和服务端分别维护了数据帧读写实现，两边的长度检查和 EOF 处理并不一致，存在以下问题。

### 客户端超长包被静默截断

协议使用 `ushort` 表示 payload 长度，最大值为 65535。

客户端发送时会先完整序列化 payload，再将长度未经检查地强制转换为 `ushort`。超过 65535 字节后，长度会按 16 位截断，客户端只发送错误长度对应的前缀。

这会导致：

- 服务端接收到截断或格式错误的数据包；
- 客户端已经在完整序列化过程中更新字符串池，但后半数据没有发送；
- 两端字符串池状态可能产生分歧；
- 最终表现为协议解析错误或异常断开。

服务端对应的写入逻辑使用 `checked`，两端行为并不一致。

### 客户端短读后继续解析

客户端读取 header 或 payload 时，如果连接在数据中间结束，原实现只将局部变量设置为 `null`，但仍继续：

- 从不完整 header 中读取长度和包类型；
- 从未完全填充的池化缓冲区中反序列化 payload；
- 使用缓冲区中残留的旧数据。

这可能将不完整数据误解析成数据包，或者产生误导性的协议异常。

### 服务端可能丢失最后一个完整包

服务端使用 `PipeReader` 读取数据。

`ReadResult.IsCompleted` 可以为 `true`，同时 `Buffer` 中仍然包含最后一批完整数据。原实现看到 `IsCompleted` 后会直接退出，尚未处理该 Buffer。

因此，对端发送最后一个完整包后立即关闭连接时，服务端可能丢失该包。

### 服务端大 payload 使用大额栈空间

服务端解析 payload 时会直接：

```csharp
stackalloc byte[size]
```

协议允许的 `size` 最大为 65535，这会为单个包在栈上分配接近 64 KiB，增加并发连接下的栈压力。

## 原因

客户端和服务端各自实现了帧写入、长度转换和读取边界处理，没有共享统一的协议限制。

客户端实现没有检查 `ushort` 转换，短读分支也没有立即终止；服务端则在消费最终 Buffer 之前检查完成状态。

## 修改

- 在共享协议层定义：
  - `Connection.PacketHeaderSize`；
  - `Connection.MaxPayloadSize = ushort.MaxValue`。
- 新增共享的 `PacketFraming`：
  - 统一 Client 和 Server 的数据帧写入；
  - 统一 payload 大小检查；
  - 提供安全的流式数据帧读取。
- payload 超过 65535 字节时抛出包含以下信息的 `PacketTooLargeException`：
  - 数据包类型；
  - 实际 payload 大小；
  - 协议允许的最大大小。
- payload 恰好为 65535 字节时仍然正常发送。
- 客户端遇到以下情况时立即结束接收，不再解析残留数据：
  - 帧边界 EOF；
  - 不完整 header；
  - 不完整 payload。
- 客户端接收循环复用 header 缓冲区，避免每包创建新的 header 数组。
- 将 `InvalidPacketDataException` 移到共享连接目录，使统一读取逻辑可以使用。
- 服务端即使收到 `IsCompleted=true`，也会先处理 Buffer 中所有完整数据帧。
- 服务端处理完最终 Buffer 后再结束 Pipe。
- 服务端按单个数据帧记录实际消费字节数。
- 服务端 payload 缓冲策略调整为：
  - 1024 字节及以下使用栈空间；
  - 更大的 payload 使用 `ArrayPool<byte>`；
  - 使用完成后始终归还池化数组。
- 提取内部 `ProcessPacketsAsync`，用于确定性测试最终 Pipe Buffer 行为。

## 协议兼容性

线上数据格式保持不变：

```text
[ushort payload size][ushort packet ID][payload]
```

此修改不会改变：

- header 字段顺序；
- 字节序；
- packet ID；
- payload 序列化格式；
- 最大合法 payload 大小。

行为变化仅限于原本无效或不完整的数据：

- 超过 65535 字节的 payload 现在明确失败，不再静默截断；
- 不完整 header 和 payload 不再尝试反序列化；
- 最终 Buffer 中的完整包不再被丢弃。

## 验证

新增 8 项数据帧测试：

1. 超过协议上限的 payload 被拒绝；
2. 恰好 65535 字节的 payload 可以写入；
3. 帧边界 EOF 返回正常结束；
4. 不完整 header 不会被解析；
5. 不完整 payload 不会被解析；
6. 现有 wire format 保持兼容并可正常读取；
7. completed Pipe 中的最后一个完整包仍会被处理；
8. 最大合法 payload 可以由服务端处理，且不进行大额栈分配。

验证结果：

- 数据帧定向测试全部通过：8/8；
- 完整单元测试通过：98/98；
- 完整 Debug 解决方案构建通过：
  - 0 个警告；
  - 0 个错误；
- Client、MockClient、Server 均成功构建；
- `git diff --check` 通过。
