### PR TITLE
fix(server): 为发送队列和请求增加背压与超时

### DIFF
--- a/source/MiaoNet.Server/Server/MiaoClientConnection.cs
+++ b/source/MiaoNet.Server/Server/MiaoClientConnection.cs
@@ -16,13 +16,29 @@ namespace MiaoNet.Server;
 public sealed class MiaoClientConnection : IPacketSerializationContext
 {
     public const int TcpBufferSize = 2048;
+    public const int PacketChannelSize = 64;
+    public const int MaxPendingRequests = 64;
 
     // TODO timeout of request
     public delegate Task ResponseHandler(PacketResponse response);
     public delegate Task ResponseHandler<in TResponse>(TResponse response) where TResponse : PacketResponse;
 
     private int currentRequestID;
-    private readonly ConcurrentDictionary<int, ResponseHandler> pendingRequests;
+    private sealed class PendingRequest(
+        ResponseHandler handler,
+        Func<Task>? timeoutHandler,
+        CancellationTokenSource cancellationTokenSource
+    ) : IDisposable
+    {
+        public ResponseHandler Handler { get; } = handler;
+        public Func<Task>? TimeoutHandler { get; } = timeoutHandler;
+        public CancellationTokenSource CancellationTokenSource { get; } = cancellationTokenSource;
+
+        public void Dispose() => CancellationTokenSource.Dispose();
+    }
+
+    private readonly ConcurrentDictionary<int, PendingRequest> pendingRequests;
+    private int pendingRequestCount;
 
     private readonly ILogger<MiaoClientConnection> logger;
     private readonly MiaoServerService server;
@@ -60,8 +76,12 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
         pipe = new();
         pendingRequests = new();
 
-        UnboundedChannelOptions options = new() { SingleReader = true };
-        sendChannel = Channel.CreateUnbounded<IContextualPacket>(options);
+        BoundedChannelOptions options = new(PacketChannelSize)
+        {
+            SingleReader = true,
+            FullMode = BoundedChannelFullMode.Wait
+        };
+        sendChannel = Channel.CreateBounded<IContextualPacket>(options);
         PooledStringManager = new(KnownPooledStrings.All);
     }
 
@@ -74,10 +94,9 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
 
         try
         {
-            Task completed = await Task.WhenAny(receivingTask, processingTask, sendingTask);
+            await Task.WhenAny(receivingTask, processingTask, sendingTask);
             await cts.CancelAsync();
-            //sendChannel.Writer.Complete();
-            await completed;
+            await Task.WhenAll(receivingTask, processingTask, sendingTask);
         }
         catch (IOException ioe)
         when (ioe.InnerException is SocketException { SocketErrorCode: SocketError.ConnectionReset or SocketError.ConnectionAborted } e)
@@ -95,6 +114,8 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
         }
         finally
         {
+            sendChannel.Writer.TryComplete();
+            await CancelPendingRequestsAsync();
             networkConnection.Dispose();
             logger.LogInformation(AppEvents.Connection, "Connection id {id} closed.", ID);
         }
@@ -109,7 +130,37 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
     #region Packet
 
     public ValueTask QueuePacketAsync(IContextualPacket packet)
-        => sendChannel.Writer.WriteAsync(packet);
+    {
+        if (sendChannel.Writer.TryWrite(packet))
+            return ValueTask.CompletedTask;
+        return WaitToQueuePacketAsync(packet);
+    }
+
+    private async ValueTask WaitToQueuePacketAsync(IContextualPacket packet)
+    {
+        using CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+        timeout.CancelAfter(server.DisconnectTimeout);
+        try
+        {
+            await sendChannel.Writer.WriteAsync(packet, timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (!cts.IsCancellationRequested)
+            {
+                logger.LogWarning(
+                    AppEvents.Connection,
+                    "Disconnecting slow client {id}: outgoing packet queue stayed full.",
+                    ID
+                );
+                await cts.CancelAsync();
+            }
+        }
+        catch (ChannelClosedException)
+        {
+            // The connection is already shutting down; there is no receiver for this packet.
+        }
+    }
 
     public bool TryQueuePacket(IContextualPacket packet)
         => sendChannel.Writer.TryWrite(packet);
@@ -117,14 +168,39 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
     // TODO maybe we can add a UserParam parameter to avoid closure
     // TODO timeout
     // TODO cancelling
-    public ValueTask RequestAsync<TResponse>(PacketRequest<TResponse> packet, ResponseHandler<TResponse> callback)
+    public async ValueTask RequestAsync<TResponse>(
+        PacketRequest<TResponse> packet,
+        ResponseHandler<TResponse> callback,
+        TimeSpan timeout,
+        Func<Task>? timeoutHandler = null,
+        CancellationToken cancellationToken = default
+    )
         where TResponse : PacketResponse
     {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+        if (Interlocked.Increment(ref pendingRequestCount) > MaxPendingRequests)
+        {
+            Interlocked.Decrement(ref pendingRequestCount);
+            throw new InvalidOperationException($"Connection {ID} has too many pending requests.");
+        }
+
         int id = Interlocked.Increment(ref currentRequestID);
         packet.RequestID = id;
-        bool success = pendingRequests.TryAdd(id, (packet) => callback((TResponse)packet));
-        Debug.Assert(success);
-        return QueuePacketAsync(packet);
+        CancellationTokenSource timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        PendingRequest pending = new(
+            response => callback((TResponse)response),
+            timeoutHandler,
+            timeoutSource
+        );
+        if (!pendingRequests.TryAdd(id, pending))
+        {
+            Interlocked.Decrement(ref pendingRequestCount);
+            pending.Dispose();
+            throw new InvalidOperationException($"Duplicate request id {id}.");
+        }
+
+        _ = ExpireRequestAsync(id, pending, timeout);
+        await QueuePacketAsync(packet);
     }
 
     public ValueTask ResponseAsync<TResponse>(PacketRequest<TResponse> request, TResponse response)
@@ -136,8 +212,13 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
 
     public ResponseHandler? OnResponse(PacketResponse response)
     {
-        if (pendingRequests.TryRemove(response.RequestID, out var handler))
+        if (TryTakePendingRequest(response.RequestID, out var pending))
+        {
+            pending.CancellationTokenSource.Cancel();
+            ResponseHandler handler = pending.Handler;
+            pending.Dispose();
             return handler;
+        }
 
         logger.LogWarning(
             "Could not find source request id of response {id}, type is {type}.",
@@ -148,6 +229,77 @@ public sealed class MiaoClientConnection : IPacketSerializationContext
             logger.LogWarning("pendingRequests has key: {key}", item.Key);
 
         return null;
+    }
+
+    private async Task ExpireRequestAsync(int id, PendingRequest pending, TimeSpan timeout)
+    {
+        try
+        {
+            await Task.Delay(timeout, pending.CancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (TryTakePendingRequest(id, out var cancelled))
+                cancelled.Dispose();
+            return;
+        }
+
+        if (!TryTakePendingRequest(id, out var expired))
+            return;
+
+        Func<Task>? timeoutHandler = expired.TimeoutHandler;
+        expired.Dispose();
+        if (timeoutHandler is null)
+            return;
+
+        try
+        {
+            await timeoutHandler();
+        }
+        catch (Exception e)
+        {
+            logger.LogError(AppEvents.Connection, e, "Request {id} timeout handler failed for connection {connectionId}.", id, ID);
+        }
+    }
+
+    private bool TryTakePendingRequest(int id, [NotNullWhen(true)] out PendingRequest? pending)
+    {
+        if (pendingRequests.TryRemove(id, out pending))
+        {
+            Interlocked.Decrement(ref pendingRequestCount);
+            return true;
+        }
+        return false;
+    }
+
+    private async Task CancelPendingRequestsAsync()
+    {
+        foreach (int id in pendingRequests.Keys)
+        {
+            if (TryTakePendingRequest(id, out var pending))
+            {
+                Func<Task>? timeoutHandler = pending.TimeoutHandler;
+                pending.CancellationTokenSource.Cancel();
+                pending.Dispose();
+                if (timeoutHandler is not null)
+                {
+                    try
+                    {
+                        await timeoutHandler();
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError(
+                            AppEvents.Connection,
+                            e,
+                            "Request {id} cancellation handler failed for connection {connectionId}.",
+                            id,
+                            ID
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #endregion

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -389,9 +389,13 @@ public sealed partial class MiaoServerService
             && target.Player.Channel == connection.Player.Channel)
         {
             logger.LogInformation(AppEvents.Game, "{p} is requesting to teleport to {p2}.", connection.Player.Info, target.Player.Info);
-            await target.RequestAsync(new PacketBeTeleportedRequest(connection.ID), OnOtherResponse);
+            await target.RequestAsync(
+                new PacketBeTeleportedRequest(connection.ID),
+                OnOtherResponse,
+                RequestTimeout,
+                OnOtherTimeout
+            );
 
-            // TODO timeout
             Task OnOtherResponse(PacketBeTeleportedResponse response)
             {
                 if (response.Accepted)
@@ -410,6 +414,20 @@ public sealed partial class MiaoServerService
                         new(PacketTeleportResponse.TeleportFailedReason.OtherDenied, null)
                     ).AsTask();
                 }
+            }
+
+            Task OnOtherTimeout()
+            {
+                logger.LogInformation(
+                    AppEvents.Game,
+                    "{p}'s teleport request to {p2} timed out.",
+                    connection.Player.Info,
+                    target.Player.Info
+                );
+                return connection.ResponseAsync(
+                    request,
+                    new(PacketTeleportResponse.TeleportFailedReason.OtherDoesNotResponse, null)
+                ).AsTask();
             }
         }
         else

--- a/source/MiaoNet.Server/Server/MiaoServerService.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.cs
@@ -44,6 +44,8 @@ public sealed partial class MiaoServerService : BackgroundService, IMiaoServerSe
 
     public int SendBatchSize => options.SendBatchSize;
 
+    public TimeSpan RequestTimeout => TimeSpan.FromMilliseconds(options.RequestTimeout);
+
     public MiaoServerService(
         ILogger<MiaoServerService> logger,
         IOptions<MiaoServerOptions> options,
@@ -244,28 +246,28 @@ public sealed partial class MiaoServerService : BackgroundService, IMiaoServerSe
 
                 async Task<TimeSpan?> PingFor(MiaoClientConnection connection, int timeout)
                 {
-                    TaskCompletionSource responseTcs = new();
+                    TaskCompletionSource<TimeSpan?> responseTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
                     var start = stopwatch.Elapsed;
-                    await connection.RequestAsync(new PacketPing(), OnResponse);
-
-                    Task timeoutTask = Task.Delay(timeout, CancellationToken.None);
-                    Task completedTask = await Task.WhenAny(responseTcs.Task, timeoutTask);
-                    if (completedTask == responseTcs.Task)
-                    {
-                        var end = stopwatch.Elapsed;
-                        return end - start;
-                    }
-                    else
-                    {
-                        logger.LogInformation(AppEvents.Connection, "{p} timeouted heartbeat.", connection.Player.Info);
-                        await connection.DisconnectAsync(DisconnectReason.Timeout);
-                        return null;
-                    }
+                    await connection.RequestAsync(
+                        new PacketPing(),
+                        OnResponse,
+                        TimeSpan.FromMilliseconds(timeout),
+                        OnTimeout,
+                        token
+                    );
+                    return await responseTcs.Task.WaitAsync(token);
 
                     Task OnResponse(PacketPong pong)
                     {
-                        responseTcs.SetResult();
+                        responseTcs.TrySetResult(stopwatch.Elapsed - start);
                         return Task.CompletedTask;
+                    }
+
+                    async Task OnTimeout()
+                    {
+                        logger.LogInformation(AppEvents.Connection, "{p} timed out heartbeat.", connection.Player.Info);
+                        await connection.DisconnectAsync(DisconnectReason.Timeout);
+                        responseTcs.TrySetResult(null);
                     }
                 }
 

--- a/source/MiaoNet.Server/Server/Options/MiaoServerOptions.cs
+++ b/source/MiaoNet.Server/Server/Options/MiaoServerOptions.cs
@@ -18,6 +18,8 @@ public sealed class MiaoServerOptions
 
     public int SendBatchSize { get; set; } = 1344;
 
+    public int RequestTimeout { get; set; } = 10000;
+
     public required CertificateOptions Certificate { get; set; }
 
     public required AuthenticationOptions Authentication { get; set; }

--- a/source/MiaoNet.Server/appsettings.json
+++ b/source/MiaoNet.Server/appsettings.json
@@ -33,6 +33,7 @@
     "DisconnectTimeout": 3000,
     "SendBatchFrequency": 90,
     "SendBatchSize": 1344,
+    "RequestTimeout": 10000,
     "HttpListenerPrefix": "http://localhost:21474/"
   }
 }

--- a/source/MiaoNet.UnitTest/MiaoClientConnectionTests.cs
+++ b/source/MiaoNet.UnitTest/MiaoClientConnectionTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MiaoNet.Server;
+using MiaoNet.Shared;
+
+namespace MiaoNet.UnitTest;
+
+[TestClass]
+public sealed class MiaoClientConnectionTests
+{
+    [TestMethod]
+    public void OutgoingQueueIsBounded()
+    {
+        var connection = CreateConnection();
+        for (int i = 0; i < MiaoClientConnection.PacketChannelSize; i++)
+            Assert.IsTrue(connection.TryQueuePacket(new PacketPing()), $"Packet {i} should fit.");
+
+        Assert.IsFalse(connection.TryQueuePacket(new PacketPing()), "The queue must apply backpressure at its configured capacity.");
+    }
+
+    [TestMethod]
+    public async Task PendingRequestIsRemovedAfterTimeout()
+    {
+        var connection = CreateConnection();
+        var request = new PacketPing();
+        TaskCompletionSource timeoutCalled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await connection.RequestAsync(
+            request,
+            _ =>
+            {
+                Assert.Fail("A response was not supplied.");
+                return Task.CompletedTask;
+            },
+            TimeSpan.FromMilliseconds(20),
+            () =>
+            {
+                timeoutCalled.TrySetResult();
+                return Task.CompletedTask;
+            }
+        );
+
+        await timeoutCalled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.IsNull(connection.OnResponse(new PacketPong { RequestID = request.RequestID }));
+    }
+
+    [TestMethod]
+    public async Task ResponseCancelsTimeoutHandler()
+    {
+        var connection = CreateConnection();
+        var request = new PacketPing();
+        bool timedOut = false;
+        bool responded = false;
+
+        await connection.RequestAsync(
+            request,
+            _ =>
+            {
+                responded = true;
+                return Task.CompletedTask;
+            },
+            TimeSpan.FromMilliseconds(100),
+            () =>
+            {
+                timedOut = true;
+                return Task.CompletedTask;
+            }
+        );
+
+        var handler = connection.OnResponse(new PacketPong { RequestID = request.RequestID });
+        Assert.IsNotNull(handler);
+        await handler(new PacketPong { RequestID = request.RequestID });
+        await Task.Delay(150);
+
+        Assert.IsTrue(responded);
+        Assert.IsFalse(timedOut);
+    }
+
+    [TestMethod]
+    public async Task PendingRequestsHaveACap()
+    {
+        var connection = CreateConnection();
+        using CancellationTokenSource cancellation = new();
+
+        for (int i = 0; i < MiaoClientConnection.MaxPendingRequests; i++)
+        {
+            await connection.RequestAsync(
+                new PacketPing(),
+                _ => Task.CompletedTask,
+                TimeSpan.FromMinutes(1),
+                cancellationToken: cancellation.Token
+            );
+        }
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+            await connection.RequestAsync(
+                new PacketPing(),
+                _ => Task.CompletedTask,
+                TimeSpan.FromMinutes(1),
+                cancellationToken: cancellation.Token
+            )
+        );
+
+        cancellation.Cancel();
+    }
+
+    private static MiaoClientConnection CreateConnection()
+    {
+        ServerChannel channel = new(0, new ChannelInfo("test"));
+        ServerPlayer player = new(channel, 1, new PlayerInfo(1, "test", string.Empty, string.Empty, Color.White));
+        return new MiaoClientConnection(
+            new FakeNetworkConnection(),
+            player,
+            NullLogger<MiaoClientConnection>.Instance,
+            null!,
+            new MiaoMetricsService()
+        );
+    }
+
+    private sealed class FakeNetworkConnection : INetworkConnection
+    {
+        public string RemoteAddress => "test";
+        public Stream Stream { get; } = new MemoryStream();
+        public void Shutdown() { }
+        public void Dispose() => Stream.Dispose();
+    }
+}


### PR DESCRIPTION
## 问题

服务端连接的发送队列和 server→client 请求生命周期缺少有效边界。

### 发送队列实际无界

`MiaoClientConnection` 声明了队列容量，但原先使用 `Channel.CreateUnbounded`。慢客户端停止读取后，发送任务会阻塞在网络写入，而广播包仍可不断进入该连接的队列，持续占用内存。

### 请求缺少统一清理

`pendingRequests` 原先只在收到响应时删除，没有统一的：

- 超时；
- 外部取消；
- 连接关闭清理；
- pending 数量上限。

Teleport 目标不响应时，请求会永久保留；heartbeat 的外层超时也不会清理底层 pending 项。

### 连接任务没有完整收尾

收包、Pipe 处理和发送任务并行运行。原实现只等待最先结束的任务，其他任务可能继续运行或留下未观察异常。

## 修改

### 有界发送队列

- 发送 Channel 容量固定为 64；
- 使用单 reader 和 `BoundedChannelFullMode.Wait`；
- 正常路径优先 `TryWrite`；
- 队列持续满到超过连接断开超时后，记录并取消慢客户端；
- 连接结束时完成 Channel writer。

该队列继续接入上游现有的时间窗口批处理逻辑，`SendBatchFrequency`、`SendBatchSize` 和 `CanBatch` 行为保持不变。

### 请求生命周期

- pending 项保存响应处理器、超时处理器和取消源；
- `RequestAsync` 必须指定超时，并支持外部 `CancellationToken`；
- 每个连接最多允许 64 个 pending request；
- 响应、超时、取消和连接关闭都会删除 pending 项并释放资源；
- 迟到响应只记录并忽略。

### Teleport 与 heartbeat

- Teleport 使用统一请求超时，默认 10 秒；
- 目标不响应时向来源返回 `OtherDoesNotResponse`；
- heartbeat 复用统一超时机制，超时时清理请求并断开客户端。

### 连接收尾

- 任一连接任务结束后取消连接；
- 使用 `Task.WhenAll` 等待并观察全部任务；
- 清理发送 Channel 和所有 pending request 后再释放网络连接。

### 配置

新增：

```json
"RequestTimeout": 10000
```

单位为毫秒，默认 10 秒。

## 行为变化

正常客户端在队列未满、请求按时响应时行为不变。以下情况得到明确处理：

- 长时间不读取数据的慢客户端会被断开；
- pending request 超过 64 个时被拒绝；
- Teleport 目标不响应时返回失败；
- heartbeat 超时不再遗留 pending 项；
- 连接关闭后不再保留请求回调；
- 所有连接任务都会被观察和收尾。

## 验证

- 连接定向测试：4/4 通过；
- Debug 完整单元测试：142/142 通过；
- Release 完整单元测试：142/142 通过；
- Debug 完整解决方案构建成功；
- Release 完整解决方案构建成功；
- Client、MockClient、Server 均成功构建；
- `git diff --check` 通过。

当前自动化测试覆盖队列容量、请求超时、正常响应取消超时和 pending 上限；尚未包含真实 TLS 慢读客户端的长时间压力测试。
