### PR TITLE
fix(server): 限制玩家状态中的 follower 数量

### DIFF
--- a/source/MiaoNet.Server/Properties/AssemblyInfo.cs
+++ b/source/MiaoNet.Server/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MiaoNet.UnitTest")]

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -44,14 +44,9 @@ public sealed partial class MiaoServerService
 
         var delta = packet.StateDelta;
 
-        int fc = delta.FollowerInitials is not null
-            ? delta.FollowerInitials.Length
-            : delta.FollowerDeltas is not null
-                ? delta.FollowerDeltas.Length
-                : 0;
-        if (fc > 12)
+        if (!PlayerPacketValidator.HasValidFollowerCount(delta))
         {
-            logger.LogWarning(AppEvents.Game, "Player {p} is taking up to {n} followers", player.Info, fc);
+            logger.LogWarning(AppEvents.Game, "Player {p} sent too many followers in a frame.", player.Info);
             await connection.DisconnectAsync(DisconnectReason.Kicked, "Too many followers");
             return;
         }
@@ -144,6 +139,12 @@ public sealed partial class MiaoServerService
                 player.Info, newLocation
             );
             await connection.DisconnectAsync(DisconnectReason.InvalidPacketWithState);
+            return;
+        }
+        if (!PlayerPacketValidator.HasValidFollowerCount(packet.InitialState))
+        {
+            logger.LogWarning(AppEvents.GameState, "Player {p} sent too many followers in its initial state.", player.Info);
+            await connection.DisconnectAsync(DisconnectReason.Kicked, "Too many followers");
             return;
         }
 

--- a/source/MiaoNet.Server/Server/PlayerPacketValidator.cs
+++ b/source/MiaoNet.Server/Server/PlayerPacketValidator.cs
@@ -1,0 +1,23 @@
+using MiaoNet.Shared;
+
+namespace MiaoNet.Server;
+
+internal static class PlayerPacketValidator
+{
+    internal const int MaxFollowersCount = 12;
+
+    internal static bool HasValidFollowerCount(PlayerState state)
+        => state.FollowerInfos is not null
+            && state.FollowerInfos.Length <= MaxFollowersCount;
+
+    internal static bool HasValidFollowerCount(PlayerStateDelta delta)
+    {
+        int count = delta.FollowerInitials is not null
+            ? delta.FollowerInitials.Length
+            : delta.FollowerDeltas is not null
+                ? delta.FollowerDeltas.Length
+                : 0;
+
+        return count <= MaxFollowersCount;
+    }
+}

--- a/source/MiaoNet.UnitTest/PlayerPacketValidatorTests.cs
+++ b/source/MiaoNet.UnitTest/PlayerPacketValidatorTests.cs
@@ -1,0 +1,62 @@
+using MiaoNet.Server;
+using MiaoNet.Shared;
+
+namespace MiaoNet.UnitTest;
+
+[TestClass]
+public sealed class PlayerPacketValidatorTests
+{
+    [TestMethod]
+    [DataRow(0, true)]
+    [DataRow(12, true)]
+    [DataRow(13, false)]
+    public void InitialState_FollowerBoundary_IsEnforced(int count, bool expected)
+    {
+        PlayerState state = CreatePlayerState(count);
+
+        Assert.AreEqual(expected, PlayerPacketValidator.HasValidFollowerCount(state));
+    }
+
+    [TestMethod]
+    [DataRow(0, true)]
+    [DataRow(12, true)]
+    [DataRow(13, false)]
+    public void DeltaFollowerInitials_Boundary_IsEnforced(int count, bool expected)
+    {
+        PlayerStateDelta delta = CreateDelta(PlayerStateDelta.FrameFlags.HasFollowerInitials);
+        delta.FollowerInitials = new FollowerInfo[count];
+
+        Assert.AreEqual(expected, PlayerPacketValidator.HasValidFollowerCount(delta));
+    }
+
+    [TestMethod]
+    [DataRow(0, true)]
+    [DataRow(12, true)]
+    [DataRow(13, false)]
+    public void DeltaFollowerDeltas_Boundary_IsEnforced(int count, bool expected)
+    {
+        PlayerStateDelta delta = CreateDelta(PlayerStateDelta.FrameFlags.HasFollowerDeltas);
+        delta.FollowerDeltas = new FollowerInfoDelta[count];
+
+        Assert.AreEqual(expected, PlayerPacketValidator.HasValidFollowerCount(delta));
+    }
+
+    private static PlayerState CreatePlayerState(int followerCount)
+        => new()
+        {
+            Position = default,
+            Animation = string.Empty,
+            AnimationFrame = 0,
+            Scale = default,
+            StateFlags = PlayerStateFlags.None,
+            Dashes = 0,
+            DeltaTime = 0,
+            PlayerSpriteMode = default,
+            HoldableInfo = default,
+            FollowerInfos = new FollowerInfo[followerCount],
+            WindDirection = default,
+        };
+
+    private static PlayerStateDelta CreateDelta(PlayerStateDelta.FrameFlags flags)
+        => new(default, string.Empty, 0, default, flags, PlayerStateFlags.None);
+}


### PR DESCRIPTION
## 问题

服务端只限制帧增量中的 follower 数量，初始玩家状态仍可携带任意数量 follower；相关校验也散落在数据包处理器中。

## 修改

- 抽出 `PlayerPacketValidator`；
- 初始 `PlayerState` 和帧 `PlayerStateDelta` 统一限制最多 12 个 follower；
- 同时覆盖 `FollowerInitials` 与 `FollowerDeltas`；
- 超限连接会被明确拒绝，不会把异常状态写入服务器；
- 增加边界和超限测试。

旧版分支还校验了 `PacketPlayerMapRoomChanged`。上游已经用统一的 `PacketPlayerLocationChanged` 替代该数据包，因此重基时删除了失效的旧包逻辑和测试。

## 最新验证

- 已重基到最新 `wip`，落后提交数为 0；
- Debug 完整解决方案：0 警告、0 错误；
- 单分支测试：99/99；
- 与其余有效修复组合后 Debug/Release 均为 0 警告、0 错误，测试 184/184。