### PR TITLE
fix(http): 修复异步响应被提前关闭

### DIFF
--- a/source/MiaoNet.Server/Http/MiaoHttpService.cs
+++ b/source/MiaoNet.Server/Http/MiaoHttpService.cs
@@ -78,30 +78,35 @@ public sealed partial class MiaoHttpService : BackgroundService
             {
                 break;
             }
-            try
-            {
-                Uri? uri = context.Request.Url;
-                if (uri is null)
-                {
-                    context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                    context.Response.Close();
-                    continue;
-                }
 
-                string path = uri.AbsolutePath;
-                NameValueCollection query = HttpUtility.ParseQueryString(uri.Query);
+            _ = HandleContextAsync(context);
+        }
+    }
 
-                _ = HandleRequestAsync(path, query, context);
-            }
-            catch (Exception e)
+    private async Task HandleContextAsync(HttpListenerContext context)
+    {
+        try
+        {
+            Uri? uri = context.Request.Url;
+            if (uri is null)
             {
-                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
-                logger.LogError(AppEvents.Http, e, "Error when handling request \"{url}\" from {ep}", context.Request.RawUrl, context.Request.RemoteEndPoint);
+                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                return;
             }
-            finally
-            {
-                context.Response.Close();
-            }
+
+            string path = uri.AbsolutePath;
+            NameValueCollection query = HttpUtility.ParseQueryString(uri.Query);
+
+            await HandleRequestAsync(path, query, context);
+        }
+        catch (Exception e)
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            logger.LogError(AppEvents.Http, e, "Error when handling request \"{url}\" from {ep}", context.Request.RawUrl, context.Request.RemoteEndPoint);
+        }
+        finally
+        {
+            context.Response.Close();
         }
     }
 


### PR DESCRIPTION
## 问题

服务端 HTTP 主循环此前以 fire-and-forget 方式调用异步 handler，随后立即进入 `finally` 并关闭 `HttpListenerResponse`。

当 JSON 序列化或响应流写入发生异步挂起时，handler 会继续写入已经关闭的响应，可能导致：

- `/status` 或 `/metrics` 返回空内容；
- JSON 响应被截断；
- 异步任务异常无人观察；
- 论坛侧短时间缺少服务端状态数据。

## 修改

- 将单个请求的解析、处理、异常处理和响应关闭集中到 `HandleContextAsync`。
- 每个请求只在对应 handler 完成后关闭自己的响应。
- 主接收循环继续立即接收并分派下一个请求，不等待当前 handler，因此不会把 HTTP 服务串行化。
- handler 内部异常仍会转换为 `500 Internal Server Error` 并记录日志。
- 保持所有端点、HTTP method、配置和访问方式不变。

本 PR 不再包含管理端点鉴权、method 限制或相关配置与文档变更。

## 并发行为

修复不会把并发数降为 1。并发请求仍由独立异步任务处理；慢响应不会阻止主循环接收后续请求。

## 验证

- Debug 单元测试：107/107 通过。
- Release 单元测试：107/107 通过。
- Debug 完整解决方案构建：0 错误。
- Release 完整解决方案构建：0 错误。
- 在临时端口启动真实 Debug 服务，并发请求 `/status` 与 `/metrics` 共 64 次：
  - 64/64 返回非空响应；
  - 64/64 均可解析为 JSON。
- `git diff --check` 通过。
