### PR TITLE
fix(client): 隔离连接生命周期并修复重连竞态

### DIFF
--- a/source/MiaoNet.Client/Connection/MiaoNetContext.Connection.cs
+++ b/source/MiaoNet.Client/Connection/MiaoNetContext.Connection.cs
@@ -11,26 +11,105 @@ namespace Celeste.Mod.MiaoNet;
 // TODO this is ugly, we need a refactor on this
 partial class MiaoNetContext
 {
+    private sealed class ConnectionOperation : IPacketSerializationContext
+    {
+        private const int EndedFlag = 1;
+        private const int ThreadCompletedFlag = 2;
+
+        private readonly CancellationTokenSource cancellation = new();
+        private MiaoServerConnection? ownedConnection;
+        private int completionState;
+
+        internal long Generation { get; }
+        internal bool ShowAvatar { get; }
+        internal string TargetServer { get; }
+        internal int TargetPort { get; }
+        internal CancellationToken Token => cancellation.Token;
+        internal PooledStringManager PooledStringManager { get; } = new(KnownPooledStrings.All);
+#if USE_CELEMIAO_AUTH
+        internal string? AuthenticationCode { get; }
+        internal byte[]? TokenData { get; }
+        internal byte[]? RefreshedAuthenticationData { get; set; }
+#endif
+
+        PooledStringManager IPacketSerializationContext.PooledStringManager => PooledStringManager;
+
+        internal ConnectionOperation(long generation, bool showAvatar, string targetServer, int targetPort)
+        {
+            Generation = generation;
+            ShowAvatar = showAvatar;
+            TargetServer = targetServer;
+            TargetPort = targetPort;
+        }
+
+#if USE_CELEMIAO_AUTH
+        internal ConnectionOperation(
+            long generation,
+            bool showAvatar,
+            string targetServer,
+            int targetPort,
+            string? authenticationCode,
+            byte[]? tokenData
+        ) : this(generation, showAvatar, targetServer, targetPort)
+        {
+            AuthenticationCode = authenticationCode;
+            TokenData = tokenData;
+        }
+#endif
+
+        internal void SetConnection(MiaoServerConnection connection)
+        {
+            if (Interlocked.CompareExchange(ref ownedConnection, connection, null) is not null)
+                throw new InvalidOperationException("The operation already owns a connection.");
+        }
+
+        internal void Cancel()
+        {
+            cancellation.Cancel();
+            MarkCompletion(EndedFlag);
+        }
+
+        internal void MarkThreadCompleted()
+            => MarkCompletion(ThreadCompletedFlag);
+
+        internal void CloseConnection(bool shutdown)
+        {
+            MiaoServerConnection? connection = Interlocked.Exchange(ref ownedConnection, null);
+            connection?.Close(shutdown);
+        }
+
+        private void MarkCompletion(int flag)
+        {
+            int state = Interlocked.Or(ref completionState, flag) | flag;
+            if (state == (EndedFlag | ThreadCompletedFlag))
+                cancellation.Dispose();
+        }
+    }
+
     private void ConnectionThread(object? param)
     {
-        var connectionToken = (CancellationToken)param!;
+        var operation = (ConnectionOperation)param!;
+        CancellationToken connectionToken = operation.Token;
 
         if (connectionToken.IsCancellationRequested)
+        {
+            operation.MarkThreadCompleted();
             return;
+        }
 
         SingleThreadedSynchronizationContext syncCtx = new();
         SingleThreadedTaskScheduler taskScheduler = new(syncCtx);
         SynchronizationContext.SetSynchronizationContext(syncCtx);
 
         CancellationTokenSource threadCts = new();
-        _ = StartConnectionAsync(this, connectionToken).ContinueWith(t =>
+        _ = StartConnectionAsync(operation, connectionToken).ContinueWith(t =>
         {
             threadCts.Cancel();
             if (t.IsFaulted)
             {
                 Logger.Error(LT.MiaoNetConnection, "Unhandled exception in connection thread!");
                 // throw to main thread
-                mainThreadQueue.Enqueue(() => throw t.Exception);
+                QueueForOperation(operation.Generation, () => throw t.Exception!);
             }
         }, taskScheduler);
 
@@ -47,15 +126,15 @@ partial class MiaoNetContext
         finally
         {
             threadCts.Dispose();
+            operation.MarkThreadCompleted();
         }
 
         Logger.Info(LT.MiaoNetConnection, "Connection thread exited.");
-        return;
 
-        async Task StartConnectionAsync(IPacketSerializationContext context, CancellationToken token)
+        async Task StartConnectionAsync(ConnectionOperation operation, CancellationToken token)
         {
 #if USE_CELEMIAO_AUTH
-            if (MiaoNetModule.Settings.TokenData is null or { Length: 0 } && ClientRC.AuthenticationCode is null)
+            if (operation.TokenData is null or { Length: 0 } && operation.AuthenticationCode is null)
             {
                 QueueDisconnectStatus(Dialog.Get("miaonet_connection_status_no_token"));
                 return;
@@ -68,8 +147,8 @@ partial class MiaoNetContext
             }
 #endif
 
-            string host = TargetServer;
-            int Port = TargetPort;
+            string host = operation.TargetServer;
+            int Port = operation.TargetPort;
 
             EndPoint ep = IPAddress.TryParse(host, out var ipa)
                 ? new IPEndPoint(ipa, Port)
@@ -81,17 +160,15 @@ partial class MiaoNetContext
             HandshakeData handshakeData;
 
 #if USE_CELEMIAO_AUTH
-            if (ClientRC.AuthenticationCode is null)
+            if (operation.AuthenticationCode is null)
             {
-                handshakeData = new HandshakeData(langCode, false, MiaoNetModule.Settings.TokenData!, netMods);
+                handshakeData = new HandshakeData(langCode, false, operation.TokenData!, netMods);
             }
             else
             {
                 Logger.Info(LT.MiaoNetConnection, "Auth code is not null, set isAuthorize to true to log in.");
-                handshakeData = new HandshakeData(langCode, true, Encoding.UTF8.GetBytes(ClientRC.AuthenticationCode), netMods);
+                handshakeData = new HandshakeData(langCode, true, Encoding.UTF8.GetBytes(operation.AuthenticationCode), netMods);
             }
-
-            ClientRC.AuthenticationCode = null;
 #else
             var settings = MiaoNetModule.Settings;
             string name = settings.Name;
@@ -108,17 +185,20 @@ partial class MiaoNetContext
             Logger.Info(LT.MiaoNetConnection, $"Trying connecting to {ep}...");
             MiaoServerConnection? connection = null;
 
-            IAsyncEnumerator<IContextualPacket> packetsAsyncEnumerator;
+            IAsyncEnumerator<IContextualPacket>? packetsAsyncEnumerator = null;
+            using CancellationTokenSource sessionCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            CancellationToken sessionToken = sessionCts.Token;
             try
             {
                 bool revocationCheck = !MiaoNetModule.Settings.IgnoreCertRevocationStatus;
-                connection = await MiaoServerConnection.CreateAsync(ep, TargetServer, revocationCheck, token);
+                connection = await MiaoServerConnection.CreateAsync(ep, operation.TargetServer, revocationCheck, token);
+                operation.SetConnection(connection);
 
                 Version localVersion = Connection.Version;
                 Version? version = await connection.MakeVersionCheck(localVersion, token);
                 if (version is not null)
                 {
-                    connection.Close(true);
+                    operation.CloseConnection(true);
                     QueueDisconnectStatus(ConnectionStatus.VersionNotMatch(localVersion, version));
                     return;
                 }
@@ -131,32 +211,24 @@ partial class MiaoNetContext
                 var r = handshakeAck.AuthenticationResultType;
                 if (r != AuthenticationResultType.Success)
                 {
-                    connection.Close(true);
+                    operation.CloseConnection(true);
                     string? reason = handshakeAck.DeniedReason;
-                    if (reason is not null)
+                    string status = r switch
                     {
-                        QueueDisconnectStatus(reason);
-                    }
-                    if (r == AuthenticationResultType.InvalidTokenData)
-                    {
-                        QueueDisconnectStatus(ConnectionStatus.InvalidTokenData);
-                    }
-                    else if (r == AuthenticationResultType.InternalServerError)
-                    {
-                        QueueDisconnectStatus(ConnectionStatus.InternalServerError);
-                    }
+                        AuthenticationResultType.InvalidTokenData => ConnectionStatus.InvalidTokenData,
+                        AuthenticationResultType.InternalServerError => ConnectionStatus.InternalServerError,
+                        _ => reason ?? ConnectionStatus.DisconnectedExceptionally,
+                    };
+                    QueueDisconnectStatus(status);
                     return;
                 }
 
 #if USE_CELEMIAO_AUTH
                 if (handshakeAck.AuthenticationData is not null)
-                {
-                    MiaoNetModule.Settings.TokenData = handshakeAck.AuthenticationData;
-                    Logger.Info(LT.MiaoNetConnection, "Server sent new auth data, accepted.");
-                }
+                    operation.RefreshedAuthenticationData = handshakeAck.AuthenticationData;
 #endif
 
-                packetsAsyncEnumerator = connection.ReceivePacketsLoopAsync(context, token).GetAsyncEnumerator(token);
+                packetsAsyncEnumerator = connection.ReceivePacketsLoopAsync(operation, sessionToken).GetAsyncEnumerator(sessionToken);
 
                 await packetsAsyncEnumerator.MoveNextAsync();
                 IContextualPacket? packetInitial = packetsAsyncEnumerator.Current;
@@ -166,41 +238,51 @@ partial class MiaoNetContext
                         Logger.Warn(LT.MiaoNetConnection, $"Remote sent empty or invalid initial reply.");
                     else
                         Logger.Warn(LT.MiaoNetConnection, $"Remote sent a weird initial packet {packetInitial.GetType()}.");
-                    connection.Close(false);
+                    await DisposePacketsAsync();
+                    operation.CloseConnection(false);
                     QueueDisconnectStatus(ConnectionStatus.DisconnectedExceptionally);
                     return;
                 }
                 else
                 {
                     Logger.Info(LT.MiaoNetConnection, $"Connected to {ep}.");
-                    TaskCompletionSource ackTaskSource = new();
+                    TaskCompletionSource ackTaskSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
                     mainThreadQueue.Enqueue(() =>
                     {
-                        OnInitialized(connection, clientInitial);
-                        ackTaskSource.SetResult();
+                        try
+                        {
+                            if (connectionLifecycle.IsCurrent(operation.Generation))
+                                OnInitialized(operation, connection, clientInitial);
+                        }
+                        finally
+                        {
+                            ackTaskSource.TrySetResult();
+                        }
                     });
                     // wait until the main thread ack we've finished connecting
-                    await ackTaskSource.Task;
-                    if (ShowAvatar)
+                    await ackTaskSource.Task.WaitAsync(token);
+                    if (operation.ShowAvatar)
                     {
                         foreach (var p in clientInitial.Players)
-                            _ = SafePrepareAvatarAsync(p.PlayerID, p.PlayerInfo);
-                        _ = SafePrepareAvatarAsync(clientInitial.PlayerID, clientInitial.SelfPlayerInfo);
+                            _ = SafePrepareAvatarAsync(operation, p.PlayerID, p.PlayerInfo);
+                        _ = SafePrepareAvatarAsync(operation, clientInitial.PlayerID, clientInitial.SelfPlayerInfo);
                     }
                 }
 
             }
-            catch (OperationCanceledException e)
-            when (e.CancellationToken == token)
+            catch (OperationCanceledException)
+            when (token.IsCancellationRequested)
             {
-                connection?.Close(false);
+                await DisposePacketsAsync();
+                operation.CloseConnection(false);
                 Logger.Info(LT.MiaoNetConnection, "Connection cancelled");
                 QueueDisconnectStatus(ConnectionStatus.Cancelled);
                 return;
             }
             catch (MiaoSslException e)
             {
-                connection?.Close(false);
+                await DisposePacketsAsync();
+                operation.CloseConnection(false);
                 Logger.Error(LT.MiaoNetConnection, $"Ssl error: {e.SslPolicyErrors}. {e.X509ChainStatusFlags}");
                 Logger.LogDetailed(e, LT.MiaoNetConnection);
                 if (e.X509ChainStatusFlags.HasFlag(X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation))
@@ -211,7 +293,8 @@ partial class MiaoNetContext
             }
             catch (Exception e)
             {
-                connection?.Close(false);
+                await DisposePacketsAsync();
+                operation.CloseConnection(false);
                 SocketException? se = (e as IOException)?.InnerException as SocketException;
                 Logger.Error(LT.MiaoNetConnection, $"Error when connecting: {e}");
                 QueueDisconnectStatus(ConnectionStatus.ConnectFailedWithReason((se ?? e).Message));
@@ -220,60 +303,78 @@ partial class MiaoNetContext
 
             try
             {
-                using (CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(token))
+                Task receiveTask = DoReceivingAndProcessingAsync(packetsAsyncEnumerator, operation, connection, sessionToken);
+                Task sendTask = connection.SendPacketsLoopAsync(operation, sessionToken);
+
+                await Task.WhenAny(receiveTask, sendTask);
+                await sessionCts.CancelAsync();
+
+                Exception? failure = null;
+                foreach (Task task in new[] { receiveTask, sendTask })
                 {
-                    Task receiveTask = DoReceivingAndProcessingAsync(packetsAsyncEnumerator, context, cts.Token);
-                    Task sendTask = connection.SendPacketsLoopAsync(context, cts.Token);
-
-                    Task task = await Task.WhenAny(receiveTask, sendTask);
-                    if (task.IsFaulted)
-                        await task;
-                    cts.Cancel();
-
-                    async Task DoReceivingAndProcessingAsync(
-                        IAsyncEnumerator<IContextualPacket> packets,
-                        IPacketSerializationContext context,
-                        CancellationToken token
-                    )
+                    try
                     {
-#if PACKET_TRACING
-                        System.Text.Json.JsonSerializerOptions options = new()
-                        {
-                            IncludeFields = true,
-                            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(System.Text.Unicode.UnicodeRanges.All),
-                            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
-                        };
-#endif
-                        while (await packets.MoveNextAsync())
-                        {
-                            var packet = packets.Current;
-
-                            if (!HandleDirectPacket(packet))
-                                receiveQueue.Enqueue(packet);
-#if PACKET_TRACING
-                            string typeName = packet.GetType().ToString();
-                            if (
-                                !typeName.Contains("Frame", StringComparison.Ordinal)
-                                && !typeName.Contains("PingData", StringComparison.Ordinal)
-                                && !typeName.Contains("UpdateOnlineStatus", StringComparison.Ordinal)
-                                && !typeName.Contains("PlayedAudio", StringComparison.Ordinal)
-                                && !typeName.Contains("PacketPing", StringComparison.Ordinal)
-                            )
-                            {
-                                var pColor = Console.ForegroundColor;
-                                Console.ForegroundColor = ConsoleColor.Green;
-                                Console.WriteLine($"== Type: {packet.GetType()} ==");
-                                Console.ForegroundColor = ConsoleColor.DarkGreen;
-                                Console.WriteLine(System.Text.Json.JsonSerializer.Serialize((object)packet, options));
-                                Console.ForegroundColor = pColor;
-                            }
-#endif
-                        }
+                        await task;
+                    }
+                    catch (OperationCanceledException) when (sessionCts.IsCancellationRequested)
+                    {
+                    }
+                    catch (Exception e)
+                    {
+                        failure ??= e;
                     }
                 }
+
+                if (failure is not null)
+                    throw failure;
+                token.ThrowIfCancellationRequested();
+
+                async Task DoReceivingAndProcessingAsync(
+                    IAsyncEnumerator<IContextualPacket> packets,
+                    ConnectionOperation operation,
+                    MiaoServerConnection connection,
+                    CancellationToken token
+                )
+                {
+#if PACKET_TRACING
+                    System.Text.Json.JsonSerializerOptions options = new()
+                    {
+                        IncludeFields = true,
+                        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(System.Text.Unicode.UnicodeRanges.All),
+                        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+                    };
+#endif
+                    while (await packets.MoveNextAsync())
+                    {
+                        var packet = packets.Current;
+
+                        if (!HandleDirectPacket(operation, connection, packet))
+                            receiveQueue.Enqueue((operation.Generation, packet));
+#if PACKET_TRACING
+                        string typeName = packet.GetType().ToString();
+                        if (
+                            !typeName.Contains("Frame", StringComparison.Ordinal)
+                            && !typeName.Contains("PingData", StringComparison.Ordinal)
+                            && !typeName.Contains("UpdateOnlineStatus", StringComparison.Ordinal)
+                            && !typeName.Contains("PlayedAudio", StringComparison.Ordinal)
+                            && !typeName.Contains("PacketPing", StringComparison.Ordinal)
+                        )
+                        {
+                            var pColor = Console.ForegroundColor;
+                            Console.ForegroundColor = ConsoleColor.Green;
+                            Console.WriteLine($"== Type: {packet.GetType()} ==");
+                            Console.ForegroundColor = ConsoleColor.DarkGreen;
+                            Console.WriteLine(System.Text.Json.JsonSerializer.Serialize((object)packet, options));
+                            Console.ForegroundColor = pColor;
+                        }
+#endif
+                    }
+                }
+
+                QueueDisconnectStatus(ConnectionStatus.Disconnected);
             }
-            catch (OperationCanceledException e)
-            when (e.CancellationToken == token)
+            catch (OperationCanceledException)
+            when (token.IsCancellationRequested)
             {
                 Logger.Info(LT.MiaoNetConnection, "Connection cancelled.");
                 QueueDisconnectStatus(ConnectionStatus.Cancelled);
@@ -287,18 +388,34 @@ partial class MiaoNetContext
                 QueueDisconnectStatus(ConnectionStatus.DisconnectedWithReason(e.Message));
                 return;
             }
+            finally
+            {
+                await DisposePacketsAsync();
+            }
+
+            async ValueTask DisposePacketsAsync()
+            {
+                if (packetsAsyncEnumerator is not null)
+                {
+                    await packetsAsyncEnumerator.DisposeAsync();
+                    packetsAsyncEnumerator = null;
+                }
+            }
         }
 
         void QueueDisconnectStatus(string statusMessage)
         {
-            mainThreadQueue.Enqueue(() =>
+            QueueForOperation(operation.Generation, () =>
             {
                 StatusComponent.ShowStatusMessage(statusMessage);
-                OnDisconnected();
+                OnDisconnected(operation.Generation);
             });
         }
 
         void QueueStatus(string statusMessage)
-            => mainThreadQueue.Enqueue(() => StatusComponent.ShowStatusMessage(statusMessage, true));
+            => QueueForOperation(
+                operation.Generation,
+                () => StatusComponent.ShowStatusMessage(statusMessage, true)
+            );
     }
 }

--- a/source/MiaoNet.Client/Connection/MiaoNetContext.cs
+++ b/source/MiaoNet.Client/Connection/MiaoNetContext.cs
@@ -14,8 +14,9 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
     private readonly ConcurrentDictionary<int, Action<PacketResponse>> pendingRequests;
     //private int warningTimes;
 
-    private CancellationTokenSource? cts;
-    private readonly ConcurrentQueue<IContextualPacket> receiveQueue;
+    private readonly ConnectionLifecycleCoordinator connectionLifecycle;
+    private ConnectionOperation? activeConnectionOperation;
+    private readonly ConcurrentQueue<(long Generation, IContextualPacket Packet)> receiveQueue;
     private readonly ConcurrentQueue<Action> mainThreadQueue;
 
     private readonly List<MiaoNetComponent> components;
@@ -98,6 +99,7 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
         receiveQueue = new();
         pendingRequests = new();
         mainThreadQueue = new();
+        connectionLifecycle = new();
 
         var main = MainComponent = new MainComponent(this);
         var pl = new PlayerListComponent(this);
@@ -118,57 +120,97 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
 
     public void Connect()
     {
-        if (cts is not null)
+        if (activeConnectionOperation is not null)
             return;
-        cts = new();
+
         // TODO hmmm tbh this is ugly, we'd better get a more elegant way to do this
         ShowAvatar = MiaoNetModule.Settings.ShowAvatar;
+        long generation = connectionLifecycle.Begin();
+#if USE_CELEMIAO_AUTH
+        string? authenticationCode = ClientRC.AuthenticationCode;
+        ClientRC.AuthenticationCode = null;
+        ConnectionOperation operation = new(
+            generation,
+            ShowAvatar,
+            TargetServer,
+            TargetPort,
+            authenticationCode,
+            MiaoNetModule.Settings.TokenData
+        );
+#else
+        ConnectionOperation operation = new(generation, ShowAvatar, TargetServer, TargetPort);
+#endif
+        activeConnectionOperation = operation;
+
         Thread connectionThread = new(new ParameterizedThreadStart(ConnectionThread));
-        connectionThread.Name = "MiaoNet Connection";
-        connectionThread.Start(cts.Token);
+        connectionThread.Name = $"MiaoNet Connection {generation}";
+        connectionThread.IsBackground = true;
+        connectionThread.Start(operation);
         StatusComponent.ShowStatusMessage(ConnectionStatus.Connecting, true);
     }
 
     public void OnConnected()
     {
-        PooledStringManager = new(KnownPooledStrings.All);
         components.ForEach(c => c.OnConnected());
     }
 
     public void Disconnect()
     {
-        if (connection is not null)
-            StatusComponent.ShowStatusMessage(ConnectionStatus.Disconnected);
-        OnDisconnected();
+        if (activeConnectionOperation is not null)
+        {
+            StatusComponent.ShowStatusMessage(
+                connection is not null ? ConnectionStatus.Disconnected : ConnectionStatus.Cancelled
+            );
+        }
+        OnDisconnected(activeConnectionOperation?.Generation);
     }
 
     public void DisconnectByException(Exception exception)
     {
         StatusComponent.ShowStatusMessage(ConnectionStatus.DisconnectedWithLocalReason(exception.Message));
-        OnDisconnected();
+        OnDisconnected(activeConnectionOperation?.Generation);
     }
 
     public void OnDisconnected()
+        => OnDisconnected(activeConnectionOperation?.Generation);
+
+    private void OnDisconnected(long? generation)
     {
-        cts?.Cancel();
-        cts = null;
+        if (generation is null)
+            return;
+
+        ConnectionOperation? operation = activeConnectionOperation;
+        if (operation is null || operation.Generation != generation.Value)
+            return;
+        if (!connectionLifecycle.TryEnd(generation.Value))
+            return;
+
+        activeConnectionOperation = null;
+        operation.Cancel();
+        bool hadConnection = connection is not null;
+
         // any better ways?
-        while (receiveQueue.TryDequeue(out var packet))
+        List<PacketDisconnected>? terminalPackets = null;
+        while (receiveQueue.TryDequeue(out var received))
         {
-            if (packet is PacketDisconnected dc)
-                packetDispatcher.DispatchPacket(dc);
+            if (received.Generation == generation.Value && received.Packet is PacketDisconnected dc)
+                (terminalPackets ??= []).Add(dc);
         }
-        receiveQueue.Clear();
         pendingRequests.Clear();
         clientState = null;
         hasComponentFocus = false;
         PooledStringManager = null;
         components?.ForEach(c => c.OnDisconnected());
-        if (connection is null)
-            return;
-        connection.Dispose();
         connection = null;
-        AvatarManager.PersistStateToDisk();
+        operation.CloseConnection(false);
+        if (hadConnection)
+            AvatarManager.PersistStateToDisk();
+
+        if (terminalPackets is not null)
+        {
+            foreach (PacketDisconnected packet in terminalPackets)
+                packetDispatcher.DispatchPacket(packet);
+        }
     }
 
     public void Update()
@@ -186,8 +228,11 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
             while (mainThreadQueue.TryDequeue(out var item))
                 item();
 
-            while (receiveQueue.TryDequeue(out var packet))
-                HandleQueuedPacket(packet);
+            while (receiveQueue.TryDequeue(out var received))
+            {
+                if (connectionLifecycle.IsCurrent(received.Generation))
+                    HandleQueuedPacket(received.Packet);
+            }
 
             if (!HasConnection)
                 return;
@@ -202,13 +247,22 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
         }
     }
 
-    private void OnInitialized(MiaoServerConnection connection, PacketClientInitial packetClientInitial)
+    private void OnInitialized(ConnectionOperation operation, MiaoServerConnection connection, PacketClientInitial packetClientInitial)
     {
+        if (!connectionLifecycle.TryMarkConnected(operation.Generation))
+            return;
+
 #if USE_CELEMIAO_AUTH
         MiaoNetModule.Settings.LastName = packetClientInitial.SelfPlayerInfo.Name;
+        if (operation.RefreshedAuthenticationData is not null)
+        {
+            MiaoNetModule.Settings.TokenData = operation.RefreshedAuthenticationData;
+            Logger.Info(LT.MiaoNetConnection, "Server sent new auth data, accepted.");
+        }
 #endif
         clientState = new(packetClientInitial);
         PlayerPresenceMessage = packetClientInitial.PlayerPresenceMessage;
+        PooledStringManager = operation.PooledStringManager;
         this.connection = connection;
         ClientInitialized?.Invoke(clientState);
         StatusComponent.ShowStatusMessage(ConnectionStatus.Connected);
@@ -218,37 +272,41 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
     }
 
     // warn: this is called on Connection Thread
-    private bool HandleDirectPacket(IContextualPacket packet)
+    private bool HandleDirectPacket(ConnectionOperation operation, MiaoServerConnection connection, IContextualPacket packet)
     {
+        if (!connectionLifecycle.IsCurrent(operation.Generation))
+            return true;
+
         if (packet is PacketPing ping)
         {
-            Response(ping, new PacketPong());
+            PacketPong pong = new() { RequestID = ping.RequestID };
+            connection.QueuePacket(pong);
             return true;
         }
         else if (packet is PacketPlayerJoined joined)
         {
-            if (ShowAvatar)
+            if (operation.ShowAvatar)
             {
                 SynchronizationContext.Current!.Post(async s =>
                 {
                     PacketPlayerJoined joined = (PacketPlayerJoined)s!;
-                    await SafePrepareAvatarAsync(joined.PlayerID, joined.PlayerInfo);
+                    await SafePrepareAvatarAsync(operation, joined.PlayerID, joined.PlayerInfo);
                 }, joined);
             }
         }
         return false;
     }
 
-    private async Task SafePrepareAvatarAsync(int playerID, PlayerInfo playerInfo)
+    private async Task SafePrepareAvatarAsync(ConnectionOperation operation, int playerID, PlayerInfo playerInfo)
     {
-        SafeGuard.Assert(ShowAvatar);
+        SafeGuard.Assert(operation.ShowAvatar);
         try
         {
             string sid = $"\0mn_avt_{playerID}";
 
             if (string.IsNullOrEmpty(playerInfo.AvatarUrl))
             {
-                mainThreadQueue.Enqueue(() =>
+                QueueForOperation(operation.Generation, () =>
                 {
                     Emoji.Register(sid, GFX.Gui["miaonet/missing_avatar"], 64, 64);
                     Emoji.Fill(MiaoNetFont.ENZhsFont);
@@ -259,7 +317,7 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
             if (!Uri.TryCreate(playerInfo.AvatarUrl, UriKind.Absolute, out Uri? uri))
             {
                 Logger.Warn(LT.MiaoNetAvatar, $"Invalid url \"{playerInfo.AvatarUrl}\" for player {playerInfo.DisplayName}.");
-                mainThreadQueue.Enqueue(() =>
+                QueueForOperation(operation.Generation, () =>
                 {
                     Emoji.Register(sid, GFX.Gui["miaonet/missing_avatar"], 64, 64);
                     Emoji.Fill(MiaoNetFont.ENZhsFont);
@@ -267,9 +325,9 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
                 return;
             }
 
-            string avatarPath = await AvatarManager.GetAsync(uri);
+            string avatarPath = await AvatarManager.GetAsync(uri).ConfigureAwait(false);
 
-            mainThreadQueue.Enqueue(() =>
+            QueueForOperation(operation.Generation, () =>
             {
                 MTexture tex;
                 try
@@ -295,6 +353,15 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
             );
             Logger.LogDetailed(e);
         }
+    }
+
+    private void QueueForOperation(long generation, Action action)
+    {
+        mainThreadQueue.Enqueue(() =>
+        {
+            if (connectionLifecycle.IsCurrent(generation))
+                action();
+        });
     }
 
     private void HandleQueuedPacket(IContextualPacket packet)

--- a/source/MiaoNet.ClientShared/ConnectionLifecycleCoordinator.cs
+++ b/source/MiaoNet.ClientShared/ConnectionLifecycleCoordinator.cs
@@ -1,0 +1,74 @@
+namespace MiaoNet.ClientShared;
+
+internal enum ConnectionLifecycleState
+{
+    Idle,
+    Connecting,
+    Connected,
+}
+
+/// <summary>
+/// Owns the generation and state transitions of a single logical connection slot.
+/// Callers must still attach resources to a generation and guard callbacks with
+/// <see cref="IsCurrent"/>.
+/// </summary>
+internal sealed class ConnectionLifecycleCoordinator
+{
+    private readonly object sync = new();
+    private long nextGeneration;
+    private long activeGeneration;
+    private ConnectionLifecycleState state;
+
+    internal ConnectionLifecycleState State
+    {
+        get
+        {
+            lock (sync)
+                return state;
+        }
+    }
+
+    internal long Begin()
+    {
+        lock (sync)
+        {
+            if (state is not ConnectionLifecycleState.Idle)
+                throw new InvalidOperationException("A connection operation is already active.");
+
+            activeGeneration = checked(++nextGeneration);
+            state = ConnectionLifecycleState.Connecting;
+            return activeGeneration;
+        }
+    }
+
+    internal bool IsCurrent(long generation)
+    {
+        lock (sync)
+            return state is not ConnectionLifecycleState.Idle && activeGeneration == generation;
+    }
+
+    internal bool TryMarkConnected(long generation)
+    {
+        lock (sync)
+        {
+            if (state is not ConnectionLifecycleState.Connecting || activeGeneration != generation)
+                return false;
+
+            state = ConnectionLifecycleState.Connected;
+            return true;
+        }
+    }
+
+    internal bool TryEnd(long generation)
+    {
+        lock (sync)
+        {
+            if (state is ConnectionLifecycleState.Idle || activeGeneration != generation)
+                return false;
+
+            activeGeneration = 0;
+            state = ConnectionLifecycleState.Idle;
+            return true;
+        }
+    }
+}

--- a/source/MiaoNet.UnitTest/ConnectionLifecycleCoordinatorTests.cs
+++ b/source/MiaoNet.UnitTest/ConnectionLifecycleCoordinatorTests.cs
@@ -1,0 +1,59 @@
+using MiaoNet.ClientShared;
+
+namespace MiaoNet.UnitTest;
+
+[TestClass]
+public sealed class ConnectionLifecycleCoordinatorTests
+{
+    [TestMethod]
+    public void BeginAndConnect_RequireTheCurrentGeneration()
+    {
+        ConnectionLifecycleCoordinator lifecycle = new();
+
+        long generation = lifecycle.Begin();
+
+        Assert.AreEqual(ConnectionLifecycleState.Connecting, lifecycle.State);
+        Assert.IsTrue(lifecycle.IsCurrent(generation));
+        Assert.IsFalse(lifecycle.TryMarkConnected(generation + 1));
+        Assert.IsTrue(lifecycle.TryMarkConnected(generation));
+        Assert.AreEqual(ConnectionLifecycleState.Connected, lifecycle.State);
+        Assert.IsFalse(lifecycle.TryMarkConnected(generation));
+    }
+
+    [TestMethod]
+    public void EndingAnOperation_IsIdempotent()
+    {
+        ConnectionLifecycleCoordinator lifecycle = new();
+        long generation = lifecycle.Begin();
+
+        Assert.IsTrue(lifecycle.TryEnd(generation));
+        Assert.IsFalse(lifecycle.TryEnd(generation));
+        Assert.AreEqual(ConnectionLifecycleState.Idle, lifecycle.State);
+    }
+
+    [TestMethod]
+    public void StaleCallbacks_CannotAffectAReplacementOperation()
+    {
+        ConnectionLifecycleCoordinator lifecycle = new();
+        long oldGeneration = lifecycle.Begin();
+        Assert.IsTrue(lifecycle.TryEnd(oldGeneration));
+
+        long newGeneration = lifecycle.Begin();
+
+        Assert.AreNotEqual(oldGeneration, newGeneration);
+        Assert.IsFalse(lifecycle.IsCurrent(oldGeneration));
+        Assert.IsFalse(lifecycle.TryMarkConnected(oldGeneration));
+        Assert.IsFalse(lifecycle.TryEnd(oldGeneration));
+        Assert.IsTrue(lifecycle.IsCurrent(newGeneration));
+        Assert.AreEqual(ConnectionLifecycleState.Connecting, lifecycle.State);
+    }
+
+    [TestMethod]
+    public void Begin_RejectsOverlappingOperations()
+    {
+        ConnectionLifecycleCoordinator lifecycle = new();
+        lifecycle.Begin();
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => lifecycle.Begin());
+    }
+}

--- a/source/MiaoNet.UnitTest/MiaoNet.UnitTest.csproj
+++ b/source/MiaoNet.UnitTest/MiaoNet.UnitTest.csproj
@@ -22,6 +22,7 @@
     <Compile Include="..\MiaoNet.Client\Command\MiaoNetCommand.cs" LinkBase="0-Shared/Command" />
     <Compile Include="..\MiaoNet.Client\Misc\SR.cs" LinkBase="0-Shared/Command" />
     <Compile Include="..\MiaoNet.Client\Misc\PFormat.cs" LinkBase="0-Shared" />
+    <Compile Include="..\MiaoNet.ClientShared\ConnectionLifecycleCoordinator.cs" LinkBase="0-Shared" />
     <Compile Include="..\MiaoNet.Shared\SafeGuard.cs" LinkBase="0-Shared/Command" />
     <Compile Include="..\ChatInputBox\ChatInputBox\ChatText*.cs" LinkBase="0-Shared/ChatInputBox" />
   </ItemGroup>


### PR DESCRIPTION
## 前置 PR

- 在 #37 后合并；两个 PR 都会修改客户端 `MiaoNetContext`。
- #37 合并后，本分支需要 rebase 到最新 `wip`。
- 解决冲突时需要保留：
  - CeleMiao 条件编译路径；
  - `LastName` 更新；
  - 刷新后认证数据的持久化；
  - 本 PR 的连接 generation 校验。
- 本 PR 也会使用 #36 修复后返回的刷新凭据，但不直接修改 #36 的服务端代码。
- rebase 后需要重新验证 Debug 和 `UseCeleMiaoAuth=true` 两种客户端构建。

## 问题

客户端连接生命周期由多个线程、异步任务和主线程回调共同管理，但原实现没有区分不同连接尝试的归属，存在以下问题。

### 正常 EOF 后仍然保持已连接状态

收包异步枚举器在远端正常关闭 TCP 时会正常结束。

原逻辑只在收发任务 fault 时处理异常。正常完成后虽然会取消关联任务，但不会排队执行 `OnDisconnected`。

因此客户端可能继续保持：

- `connection` 不为空；
- 根连接 CTS 不为空；
- UI 显示已连接；
- 后续发送继续进入已经失效的连接；
- 再次调用 `Connect` 被拒绝。

### 旧连接回调可以影响新连接

断开时会立即清空当前 CTS 和连接字段，但不会等待旧连接线程完全结束。

旧线程仍可能在主线程队列中留下：

- `OnInitialized`；
- `OnDisconnected`；
- 状态提示；
- 收包回调；
- 头像加载完成回调。

如果用户快速执行“断开→重新连接”，旧连接回调可能在新连接建立后执行，造成：

- 旧连接的断开回调关闭新连接；
- 已经取消的旧连接重新执行初始化；
- UI 被旧状态覆盖；
- 旧包进入新连接状态；
- 旧头像任务修改新会话资源。

### 连接线程可能阻止退出

连接线程使用普通前台 `Thread`。

握手成功后，连接线程会排队执行主线程初始化，并无限等待主线程确认。如果游戏正在退出、模块卸载或主线程不再处理队列，该等待无法响应取消。

结果可能是：

- 连接线程永久阻塞；
- socket 和取消源无法释放；
- 前台线程阻止进程正常退出或热重载。

### 收发任务没有统一收尾

连接建立后会同时运行收包和发包任务。

原实现等待其中一个任务结束，只在该任务 fault 时观察异常，然后取消 CTS，但不会可靠地等待并观察另一个任务，也没有显式释放异步收包枚举器。

## 原因

所有连接尝试共享以下可变字段：

- CTS；
- socket/connection；
- `PooledStringManager`；
- 目标服务器；
- 头像设置；
- 认证 code 和 token；
- 主线程回调队列；
- 收包队列。

回调本身没有携带连接身份，因此无法判断执行时是否仍然属于当前连接。

## 修改

### 连接 generation

新增 `ConnectionLifecycleCoordinator`。

每次 `Connect` 分配单调递增的 generation，并维护：

```text
Idle → Connecting → Connected → Idle
```

只有当前 generation 可以：

- 完成连接初始化；
- 更新连接状态；
- 投递和处理数据包；
- 保存刷新后的认证数据；
- 更新头像资源；
- 执行断开清理。

旧 generation 的回调即使稍后到达，也不会操作当前连接。

### 每次连接独立持有资源

新增 `ConnectionOperation`，每次连接独立持有：

- generation；
- CancellationTokenSource；
- `MiaoServerConnection`；
- `PooledStringManager`；
- 目标服务器和端口快照；
- `ShowAvatar` 快照；
- CeleMiao authentication code；
- CeleMiao token 数据；
- 服务端返回的刷新认证数据。

连接期间不再反复读取可能被下一次连接修改的全局字段。

### 初始化与断开

- `OnInitialized` 必须验证当前 generation。
- 每个 generation 最多执行一次结束清理。
- 旧连接不能关闭新连接。
- 旧连接不能在取消后重新初始化。
- `PacketDisconnected` 中的服务端断开原因仍然优先显示。
- 正常 EOF 现在会排队显示 `Disconnected` 并清理连接。
- 用户在连接过程中主动取消时继续显示 `Cancelled`。
- 异常断开继续保留原始错误原因。

### 主线程回调

新增按 generation 保护的主线程入队方法。

以下回调执行前都会确认仍属于当前连接：

- 连接状态；
- 初始化；
- 数据包；
- 头像注册；
- 连接异常；
- 断开清理。

收包队列中的每个包也会携带对应 generation。

### 认证数据

CeleMiao authentication code 和 token 在开始连接时创建快照。

服务端返回的刷新认证数据只会在对应 generation 成功完成初始化后写入设置，避免旧连接覆盖新连接的认证状态。

### 线程和任务收尾

- 连接线程设置为后台线程。
- 主线程初始化确认改用：

  ```csharp
  ackTaskSource.Task.WaitAsync(token)
  ```

  可以响应连接取消。
- 收包或发包任一任务结束时取消另一个任务。
- 分别等待并观察两个任务。
- 保留第一个非取消异常并进入统一断开流程。
- 显式调用异步收包枚举器的 `DisposeAsync`。
- 连接线程结束和连接操作结束共同控制 CTS 的最终释放。
- socket 只能由所属的 `ConnectionOperation` 关闭。

## 行为变化

正常连接流程和协议保持不变。

修复后的可见行为包括：

- 远端正常关闭连接后，客户端会正确回到未连接状态；
- 正常 EOF 后可以再次连接；
- 快速断开重连时，旧连接不会终止新连接；
- 取消中的旧连接不会重新完成初始化；
- 游戏退出或模块停止处理主线程队列时，连接线程不再永久阻止进程退出；
- 旧连接的包和头像任务不会进入新连接状态。

## 验证

新增 4 项连接生命周期状态测试：

1. 只有当前 generation 可以从 Connecting 进入 Connected；
2. 同一连接的结束操作是幂等的；
3. 旧 generation 无法初始化或结束替代它的新连接；
4. 已有活动连接时拒绝启动重叠连接。

验证结果：

- 生命周期定向测试全部通过：4/4；
- 完整单元测试通过：94/94；
- 完整 Debug 解决方案构建通过：
  - 0 个警告；
  - 0 个错误；
- `UseCeleMiaoAuth=true` 客户端变体构建通过：
  - 0 个警告；
  - 0 个错误；
- `git diff --check` 通过。

状态机和资源归属已由自动化测试覆盖；真实 Celeste 主线程中的快速断开重连和进程退出场景尚未建立自动化端到端测试。
