### PR TITLE
fix(interactions): 校验玩家抓取状态与释放力度

### DIFF
--- a/source/MiaoNet.Client/Components/MainComponent.Interactions.cs
+++ b/source/MiaoNet.Client/Components/MainComponent.Interactions.cs
@@ -156,22 +156,20 @@ partial class MainComponent
             }
             else
             {
-                var playerEntity = level.Tracker.GetEntity<Player>();
-                if (playerEntity is not null)
+                Player? playerEntity = level.Tracker.GetEntity<Player>();
+                if (playerEntity is not null
+                    && playerEntity.InControl
+                    && ghosts.TryGetValue(player.ID, out MiaoNetGhost? ghost))
                 {
-                    if (playerEntity.InControl)
-                    {
-                        // let them hold us
-                        heldByPlayerGhost = ghosts[player.ID];
-                        OnHeldBy(playerEntity);
-                    }
-                    else
-                    {
-                        // not now
-                        context.QueuePacket(new PacketPlayerGrabJumpOut(player.ID));
-                    }
+                    // let them hold us
+                    heldByPlayerGhost = ghost;
+                    OnHeldBy(playerEntity);
                 }
-                // should we tell the other that no player locally found?
+                else
+                {
+                    // The sender may have left our sync scope while the packet was queued.
+                    context.QueuePacket(new PacketPlayerGrabJumpOut(player.ID));
+                }
             }
         }
         else

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -456,11 +456,27 @@ public sealed partial class MiaoServerService
     {
         if (!ServerState.Players.TryGetValue(packet.PlayerID, out var p))
             return;
-        // holding requires the same channel and the same map
-        if (p.Player.Channel != connection.Player.Channel
-            || p.Player.Location.Map != connection.Player.Location.Map)
+        // Both grab and release packets are only valid inside the normal sync scope.
+        if (!p.Player.ShouldSyncFrom(connection.Player))
             return;
-        // TODO verify this action server-side
+
+        if (!packet.IsRelease && !PlayerInteractionValidator.CanGrab(connection.Player, p.Player))
+        {
+            logger.LogWarning(
+                AppEvents.GameState,
+                "Player {source} tried to grab {target} outside an enabled sync scope.",
+                connection.Player.Info,
+                p.Player.Info
+            );
+            return;
+        }
+
+        if (packet.IsRelease && !PlayerInteractionValidator.IsValidReleaseForce(packet.Force))
+        {
+            logger.LogWarning(AppEvents.GameState, "Player {source} sent an invalid release force.", connection.Player.Info);
+            return;
+        }
+
         PacketPlayerGrabPlayer send = packet.IsRelease ? new(connection.ID, packet.Force) : new(connection.ID);
         await p.QueuePacketAsync(send);
     }

--- a/source/MiaoNet.Server/Server/PlayerInteractionValidator.cs
+++ b/source/MiaoNet.Server/Server/PlayerInteractionValidator.cs
@@ -1,0 +1,14 @@
+using MiaoNet.Shared;
+
+namespace MiaoNet.Server;
+
+internal static class PlayerInteractionValidator
+{
+    internal static bool CanGrab(ServerPlayer source, ServerPlayer target)
+        => target.ShouldSyncFrom(source)
+            && target.GlobalFlags.HasFlag(PlayerGlobalFlags.Interactions)
+            && source.GlobalFlags.HasFlag(PlayerGlobalFlags.Interactions);
+
+    internal static bool IsValidReleaseForce(Vector2 force)
+        => float.IsFinite(force.X) && float.IsFinite(force.Y);
+}

--- a/source/MiaoNet.UnitTest/PlayerInteractionValidatorTests.cs
+++ b/source/MiaoNet.UnitTest/PlayerInteractionValidatorTests.cs
@@ -1,0 +1,40 @@
+using MiaoNet.Server;
+using MiaoNet.Shared;
+
+namespace MiaoNet.UnitTest;
+
+[TestClass]
+public sealed class PlayerInteractionValidatorTests
+{
+    [TestMethod]
+    public void GrabRequiresSameSyncScopeAndBothPlayersOptedIn()
+    {
+        ServerChannel channel = new(0, new ChannelInfo("test"));
+        ServerPlayer source = CreatePlayer(channel, 1);
+        ServerPlayer target = CreatePlayer(channel, 2);
+
+        Assert.IsTrue(PlayerInteractionValidator.CanGrab(source, target));
+
+        target.GlobalFlags = PlayerGlobalFlags.None;
+        Assert.IsFalse(PlayerInteractionValidator.CanGrab(source, target));
+
+        target.GlobalFlags = PlayerGlobalFlags.Interactions;
+        target.Location = new PlayerLocation("Other/Map", AreaMode.Normal, "room");
+        Assert.IsFalse(PlayerInteractionValidator.CanGrab(source, target));
+    }
+
+    [TestMethod]
+    public void ReleaseForceMustBeFinite()
+    {
+        Assert.IsTrue(PlayerInteractionValidator.IsValidReleaseForce(new Vector2(1, -1)));
+        Assert.IsFalse(PlayerInteractionValidator.IsValidReleaseForce(new Vector2(float.NaN, 0)));
+        Assert.IsFalse(PlayerInteractionValidator.IsValidReleaseForce(new Vector2(0, float.PositiveInfinity)));
+    }
+
+    private static ServerPlayer CreatePlayer(ServerChannel channel, int id)
+        => new(channel, id, new PlayerInfo(id, $"p{id}", string.Empty, string.Empty, Color.White))
+        {
+            Location = new PlayerLocation("Test/Map", AreaMode.Normal, "room"),
+            GlobalFlags = PlayerGlobalFlags.Interactions
+        };
+}


### PR DESCRIPTION
## 问题

玩家抓取交互在客户端和服务端缺少必要的状态检查。

### 客户端队列竞态

客户端收到远端玩家抓取请求后，会直接通过玩家 ID 索引 ghost。

抓取包进入接收队列后，远端玩家可能在实际处理前离开同步范围，对应 ghost 会被移除。此时直接索引字典会抛出 `KeyNotFoundException`，并可能导致整个 MiaoNet 连接断开。

### 服务端校验不足

服务端原本只检查目标玩家是否存在、是否位于相同频道和地图，没有完整验证：

- 来源与目标是否仍处于正常同步范围；
- 双方是否都启用了 `PlayerGlobalFlags.Interactions`；
- 释放力度是否包含 `NaN` 或 `Infinity`。

## 修改

### 客户端抓取处理

收到抓取请求时同时要求：

- 当前场景存在本地 Player；
- 本地 Player 仍可控制；
- 发送者仍存在对应的 `MiaoNetGhost`。

任一条件不满足时，不修改本地抓取状态，并向发送者返回 `PacketPlayerGrabJumpOut`。

### 服务端抓取校验

新增 `PlayerInteractionValidator`：

- 抓取要求目标允许从来源同步；
- 抓取要求双方都启用交互；
- 抓取和释放都必须处于正常同步范围；
- 非法请求只记录并忽略，不影响其他连接。

### 释放力度

释放包中的两个分量都必须满足：

```csharp
float.IsFinite(force.X)
float.IsFinite(force.Y)
```

包含 `NaN` 或 `Infinity` 的释放包不会转发。

### 保持原版释放行为

客户端脱墙逻辑保持不变，继续与 `Celeste.Holdable.Release(Vector2 force)` 一致。本 PR 不再修改释放后的碰撞搜索策略。

## 行为变化

正常的同范围玩家抓取和释放行为保持不变。以下情况会被安全拒绝：

- 抓取包处理时 ghost 已移除；
- 本地 Player 不存在或暂不可控制；
- 双方不在相同同步范围；
- 任一玩家未启用交互；
- 释放力度包含非有限浮点值。

## 验证

- 服务端交互校验定向测试：2/2 通过，覆盖 5 个条件场景；
- Debug 完整单元测试：134/134 通过；
- Release 完整单元测试：134/134 通过；
- Debug 完整解决方案构建成功；
- Release 完整解决方案构建成功；
- Client、MockClient、Server 均成功构建；
- `git diff --check` 通过。
