### PR TITLE
fix(client): 加固头像下载边界与 SSRF 防护

### DIFF
--- a/source/MiaoNet.Client/Misc/AvatarDownloadPolicy.cs
+++ b/source/MiaoNet.Client/Misc/AvatarDownloadPolicy.cs
@@ -54,9 +54,7 @@ internal static class AvatarDownloadPolicy
 
     internal static bool IsSupportedImage(ReadOnlySpan<byte> data)
     {
-        if (TryReadPngDimensions(data, out int width, out int height)
-            || TryReadGifDimensions(data, out width, out height)
-            || TryReadJpegDimensions(data, out width, out height))
+        if (TryReadPngDimensions(data, out int width, out int height))
         {
             return width is > 0 and <= MaxImageDimension
                 && height is > 0 and <= MaxImageDimension;
@@ -74,53 +72,6 @@ internal static class AvatarDownloadPolicy
             return true;
         }
         width = height = 0;
-        return false;
-    }
-
-    private static bool TryReadGifDimensions(ReadOnlySpan<byte> data, out int width, out int height)
-    {
-        if (data.Length >= 10 && (data[..6].SequenceEqual("GIF87a"u8) || data[..6].SequenceEqual("GIF89a"u8)))
-        {
-            width = BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(6, 2));
-            height = BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(8, 2));
-            return true;
-        }
-        width = height = 0;
-        return false;
-    }
-
-    private static bool TryReadJpegDimensions(ReadOnlySpan<byte> data, out int width, out int height)
-    {
-        width = height = 0;
-        if (data.Length < 4 || data[0] != 0xff || data[1] != 0xd8)
-            return false;
-
-        int offset = 2;
-        while (offset + 4 <= data.Length)
-        {
-            while (offset < data.Length && data[offset] == 0xff)
-                offset++;
-            if (offset >= data.Length)
-                return false;
-            byte marker = data[offset++];
-            if (marker is 0xd8 or 0xd9 || marker is >= 0xd0 and <= 0xd7)
-                continue;
-            if (offset + 2 > data.Length)
-                return false;
-            int segmentLength = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, 2));
-            if (segmentLength < 2 || offset + segmentLength > data.Length)
-                return false;
-            if (marker is 0xc0 or 0xc1 or 0xc2 or 0xc3 or 0xc5 or 0xc6 or 0xc7
-                or 0xc9 or 0xca or 0xcb or 0xcd or 0xce or 0xcf)
-            {
-                if (segmentLength < 7)
-                    return false;
-                height = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset + 3, 2));
-                width = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset + 5, 2));
-                return true;
-            }
-            offset += segmentLength;
-        }
         return false;
     }
 }

--- a/source/MiaoNet.Client/Misc/AvatarDownloadPolicy.cs
+++ b/source/MiaoNet.Client/Misc/AvatarDownloadPolicy.cs
@@ -1,0 +1,126 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Celeste.Mod.MiaoNet;
+
+internal static class AvatarDownloadPolicy
+{
+    internal const int MaxDownloadBytes = 2 * 1024 * 1024;
+    internal const int MaxImageDimension = 2048;
+    internal const int MaxRedirects = 3;
+
+    internal static bool IsAllowedUri(Uri uri)
+        => uri.IsAbsoluteUri
+            && uri.Scheme == Uri.UriSchemeHttps
+            && string.IsNullOrEmpty(uri.UserInfo);
+
+    internal static bool IsPublicAddress(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            ReadOnlySpan<byte> bytes = address.GetAddressBytes();
+            byte a = bytes[0], b = bytes[1], c = bytes[2];
+            return a != 0 && a != 10 && a != 127
+                && !(a == 100 && b is >= 64 and <= 127)
+                && !(a == 169 && b == 254)
+                && !(a == 172 && b is >= 16 and <= 31)
+                && !(a == 192 && b == 0 && c is 0 or 2)
+                && !(a == 192 && b == 168)
+                && !(a == 198 && b is 18 or 19)
+                && !(a == 198 && b == 51 && c == 100)
+                && !(a == 203 && b == 0 && c == 113)
+                && a < 224;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            ReadOnlySpan<byte> bytes = address.GetAddressBytes();
+            return !IPAddress.IsLoopback(address)
+                && !address.IsIPv6LinkLocal
+                && !address.IsIPv6Multicast
+                && !address.IsIPv6SiteLocal
+                && !(bytes[0] is 0xfc or 0xfd)
+                && !(bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0d && bytes[3] == 0xb8)
+                && !address.Equals(IPAddress.IPv6Any)
+                && !address.Equals(IPAddress.IPv6None);
+        }
+
+        return false;
+    }
+
+    internal static bool IsSupportedImage(ReadOnlySpan<byte> data)
+    {
+        if (TryReadPngDimensions(data, out int width, out int height)
+            || TryReadGifDimensions(data, out width, out height)
+            || TryReadJpegDimensions(data, out width, out height))
+        {
+            return width is > 0 and <= MaxImageDimension
+                && height is > 0 and <= MaxImageDimension;
+        }
+        return false;
+    }
+
+    private static bool TryReadPngDimensions(ReadOnlySpan<byte> data, out int width, out int height)
+    {
+        ReadOnlySpan<byte> signature = [137, 80, 78, 71, 13, 10, 26, 10];
+        if (data.Length >= 24 && data[..8].SequenceEqual(signature) && data.Slice(12, 4).SequenceEqual("IHDR"u8))
+        {
+            width = BinaryPrimitives.ReadInt32BigEndian(data.Slice(16, 4));
+            height = BinaryPrimitives.ReadInt32BigEndian(data.Slice(20, 4));
+            return true;
+        }
+        width = height = 0;
+        return false;
+    }
+
+    private static bool TryReadGifDimensions(ReadOnlySpan<byte> data, out int width, out int height)
+    {
+        if (data.Length >= 10 && (data[..6].SequenceEqual("GIF87a"u8) || data[..6].SequenceEqual("GIF89a"u8)))
+        {
+            width = BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(6, 2));
+            height = BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(8, 2));
+            return true;
+        }
+        width = height = 0;
+        return false;
+    }
+
+    private static bool TryReadJpegDimensions(ReadOnlySpan<byte> data, out int width, out int height)
+    {
+        width = height = 0;
+        if (data.Length < 4 || data[0] != 0xff || data[1] != 0xd8)
+            return false;
+
+        int offset = 2;
+        while (offset + 4 <= data.Length)
+        {
+            while (offset < data.Length && data[offset] == 0xff)
+                offset++;
+            if (offset >= data.Length)
+                return false;
+            byte marker = data[offset++];
+            if (marker is 0xd8 or 0xd9 || marker is >= 0xd0 and <= 0xd7)
+                continue;
+            if (offset + 2 > data.Length)
+                return false;
+            int segmentLength = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, 2));
+            if (segmentLength < 2 || offset + segmentLength > data.Length)
+                return false;
+            if (marker is 0xc0 or 0xc1 or 0xc2 or 0xc3 or 0xc5 or 0xc6 or 0xc7
+                or 0xc9 or 0xca or 0xcb or 0xcd or 0xce or 0xcf)
+            {
+                if (segmentLength < 7)
+                    return false;
+                height = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset + 3, 2));
+                width = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset + 5, 2));
+                return true;
+            }
+            offset += segmentLength;
+        }
+        return false;
+    }
+}

--- a/source/MiaoNet.Client/Misc/AvatarManager.cs
+++ b/source/MiaoNet.Client/Misc/AvatarManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -27,7 +28,14 @@ public static class AvatarManager
 
     static AvatarManager()
     {
-        httpClient = new();
+        SocketsHttpHandler handler = new()
+        {
+            AllowAutoRedirect = false,
+            UseProxy = false,
+            ConnectTimeout = TimeSpan.FromSeconds(10),
+            ConnectCallback = ConnectPublicHostAsync
+        };
+        httpClient = new(handler) { Timeout = TimeSpan.FromSeconds(20) };
         httpClient.DefaultRequestHeaders.Add("User-Agent", "MiaoNet Client Avatar Http Client");
         memoryCache = new();
 
@@ -76,6 +84,9 @@ public static class AvatarManager
 
     public static async ValueTask<string> GetAsync(Uri uri)
     {
+        if (!AvatarDownloadPolicy.IsAllowedUri(uri))
+            throw new InvalidDataException($"Avatar URL is not an allowed HTTPS URL: {uri}");
+
         if (memoryCache.TryGetValue(uri, out var cache) && File.Exists(Path.Combine(PathAvatarCache, cache.FileName)))
         {
             if (cache.CacheControlMaxAge is TimeSpan timeSpan && DateTime.UtcNow < cache.FetchTime + timeSpan)
@@ -86,14 +97,7 @@ public static class AvatarManager
 
             if (cache.ETag is not null || cache.LastModified is not null)
             {
-                HttpRequestMessage req = new(HttpMethod.Get, uri);
-
-                if (cache.ETag is not null)
-                    req.Headers.IfNoneMatch.Add(new(cache.ETag));
-                if (cache.LastModified is not null)
-                    req.Headers.IfModifiedSince = cache.LastModified;
-
-                var res = await httpClient.SendAsync(req);
+                using var res = await SendAsync(uri, cache);
 
                 cache.FetchTime = DateTime.UtcNow;
                 cache.CacheControlMaxAge = res.Headers.CacheControl?.MaxAge;
@@ -120,7 +124,8 @@ public static class AvatarManager
     FullFetch:
         {
             Logger.Debug(LT.MiaoNetAvatar, $"No cache found, requesting {uri}...");
-            var res = await httpClient.GetAsync(uri);
+            using var res = await SendAsync(uri, null);
+            res.EnsureSuccessStatusCode();
 
             var cacheControlMaxAge = res.Headers.CacheControl?.MaxAge;
             var lastModified = res.Content.Headers.LastModified;
@@ -144,10 +149,96 @@ public static class AvatarManager
 
     private static async Task FetchAndSave(HttpResponseMessage message, string fileName)
     {
-        var arr = await message.Content.ReadAsByteArrayAsync();
+        if (message.Content.Headers.ContentLength > AvatarDownloadPolicy.MaxDownloadBytes)
+            throw new InvalidDataException("Avatar is larger than the allowed download size.");
+
+        await using Stream source = await message.Content.ReadAsStreamAsync();
+        using MemoryStream destination = new();
+        byte[] buffer = new byte[16 * 1024];
+        int total = 0;
+        while (true)
+        {
+            int read = await source.ReadAsync(buffer);
+            if (read == 0)
+                break;
+            total = checked(total + read);
+            if (total > AvatarDownloadPolicy.MaxDownloadBytes)
+                throw new InvalidDataException("Avatar is larger than the allowed download size.");
+            destination.Write(buffer, 0, read);
+        }
+
+        byte[] arr = destination.ToArray();
+        if (!AvatarDownloadPolicy.IsSupportedImage(arr))
+            throw new InvalidDataException("Avatar is not a supported image or exceeds the dimension limit.");
 
         Directory.CreateDirectory(PathAvatarCache);
         string pathToAvatarCacheFile = Path.Combine(PathAvatarCache, fileName);
-        await File.WriteAllBytesAsync(pathToAvatarCacheFile, arr);
+        string temporaryPath = pathToAvatarCacheFile + ".tmp";
+        await File.WriteAllBytesAsync(temporaryPath, arr);
+        File.Move(temporaryPath, pathToAvatarCacheFile, true);
+    }
+
+    private static async Task<HttpResponseMessage> SendAsync(Uri initialUri, CacheInfo? cache)
+    {
+        Uri uri = initialUri;
+        for (int redirects = 0; ; redirects++)
+        {
+            if (!AvatarDownloadPolicy.IsAllowedUri(uri))
+                throw new InvalidDataException($"Avatar redirect is not an allowed HTTPS URL: {uri}");
+
+            using HttpRequestMessage request = new(HttpMethod.Get, uri);
+            if (cache is CacheInfo cacheInfo)
+            {
+                if (cacheInfo.ETag is not null)
+                    request.Headers.IfNoneMatch.Add(new(cacheInfo.ETag));
+                if (cacheInfo.LastModified is not null)
+                    request.Headers.IfModifiedSince = cacheInfo.LastModified;
+            }
+
+            HttpResponseMessage response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            if (!IsRedirect(response.StatusCode))
+                return response;
+
+            Uri? location = response.Headers.Location;
+            response.Dispose();
+            if (location is null || redirects >= AvatarDownloadPolicy.MaxRedirects)
+                throw new InvalidDataException("Avatar download has an invalid or excessive redirect chain.");
+            uri = location.IsAbsoluteUri ? location : new Uri(uri, location);
+        }
+    }
+
+    private static bool IsRedirect(HttpStatusCode statusCode)
+        => statusCode is HttpStatusCode.Moved
+            or HttpStatusCode.Redirect
+            or HttpStatusCode.RedirectMethod
+            or HttpStatusCode.TemporaryRedirect
+            or HttpStatusCode.PermanentRedirect;
+
+    private static async ValueTask<Stream> ConnectPublicHostAsync(
+        SocketsHttpConnectionContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        IPAddress[] addresses = await Dns.GetHostAddressesAsync(context.DnsEndPoint.Host, cancellationToken);
+        IPAddress[] allowed = addresses.Where(AvatarDownloadPolicy.IsPublicAddress).ToArray();
+        if (allowed.Length == 0)
+            throw new InvalidDataException("Avatar host does not resolve to a public IP address.");
+
+        Exception? lastError = null;
+        foreach (IPAddress address in allowed)
+        {
+            Socket socket = new(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            try
+            {
+                await socket.ConnectAsync(new IPEndPoint(address, context.DnsEndPoint.Port), cancellationToken);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (Exception e)
+            {
+                socket.Dispose();
+                lastError = e;
+            }
+        }
+        throw new IOException("Could not connect to an allowed avatar host.", lastError);
     }
 }

--- a/source/MiaoNet.UnitTest/AvatarDownloadPolicyTests.cs
+++ b/source/MiaoNet.UnitTest/AvatarDownloadPolicyTests.cs
@@ -50,4 +50,14 @@ public sealed class AvatarDownloadPolicyTests
         Assert.IsFalse(AvatarDownloadPolicy.IsSupportedImage(png));
         Assert.IsFalse(AvatarDownloadPolicy.IsSupportedImage("not an image"u8));
     }
+
+    [TestMethod]
+    public void RejectsGifAndJpegImages()
+    {
+        ReadOnlySpan<byte> gif = [71, 73, 70, 56, 57, 97, 64, 0, 64, 0];
+        ReadOnlySpan<byte> jpeg = [0xff, 0xd8, 0xff, 0xc0, 0, 7, 8, 0, 64, 0, 64];
+
+        Assert.IsFalse(AvatarDownloadPolicy.IsSupportedImage(gif));
+        Assert.IsFalse(AvatarDownloadPolicy.IsSupportedImage(jpeg));
+    }
 }

--- a/source/MiaoNet.UnitTest/AvatarDownloadPolicyTests.cs
+++ b/source/MiaoNet.UnitTest/AvatarDownloadPolicyTests.cs
@@ -1,0 +1,53 @@
+using System.Buffers.Binary;
+using System.Net;
+using Celeste.Mod.MiaoNet;
+
+namespace MiaoNet.UnitTest;
+
+[TestClass]
+public sealed class AvatarDownloadPolicyTests
+{
+    [TestMethod]
+    public void OnlyAllowsCredentialFreeHttpsUrls()
+    {
+        Assert.IsTrue(AvatarDownloadPolicy.IsAllowedUri(new Uri("https://cdn.example/avatar.png")));
+        Assert.IsFalse(AvatarDownloadPolicy.IsAllowedUri(new Uri("http://cdn.example/avatar.png")));
+        Assert.IsFalse(AvatarDownloadPolicy.IsAllowedUri(new Uri("https://user:secret@cdn.example/avatar.png")));
+        Assert.IsFalse(AvatarDownloadPolicy.IsAllowedUri(new Uri("file:///etc/passwd")));
+    }
+
+    [TestMethod]
+    [DataRow("127.0.0.1")]
+    [DataRow("10.0.0.1")]
+    [DataRow("172.16.0.1")]
+    [DataRow("192.168.1.1")]
+    [DataRow("169.254.1.1")]
+    [DataRow("100.64.0.1")]
+    [DataRow("::1")]
+    [DataRow("fd00::1")]
+    [DataRow("fe80::1")]
+    public void RejectsNonPublicAddresses(string text)
+        => Assert.IsFalse(AvatarDownloadPolicy.IsPublicAddress(IPAddress.Parse(text)));
+
+    [TestMethod]
+    [DataRow("1.1.1.1")]
+    [DataRow("8.8.8.8")]
+    [DataRow("2606:4700:4700::1111")]
+    public void AllowsPublicAddresses(string text)
+        => Assert.IsTrue(AvatarDownloadPolicy.IsPublicAddress(IPAddress.Parse(text)));
+
+    [TestMethod]
+    public void ValidatesPngDimensions()
+    {
+        byte[] png = new byte[24];
+        new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }.CopyTo(png, 0);
+        "IHDR"u8.CopyTo(png.AsSpan(12));
+        BinaryPrimitives.WriteInt32BigEndian(png.AsSpan(16, 4), 64);
+        BinaryPrimitives.WriteInt32BigEndian(png.AsSpan(20, 4), 64);
+        Assert.IsTrue(AvatarDownloadPolicy.IsSupportedImage(png));
+
+        BinaryPrimitives.WriteInt32BigEndian(png.AsSpan(16, 4), AvatarDownloadPolicy.MaxImageDimension + 1);
+        Assert.IsFalse(AvatarDownloadPolicy.IsSupportedImage(png));
+        Assert.IsFalse(AvatarDownloadPolicy.IsSupportedImage("not an image"u8));
+    }
+}

--- a/source/MiaoNet.UnitTest/MiaoNet.UnitTest.csproj
+++ b/source/MiaoNet.UnitTest/MiaoNet.UnitTest.csproj
@@ -23,6 +23,7 @@
     <Compile Include="..\MiaoNet.Client\Misc\SR.cs" LinkBase="0-Shared/Command" />
     <Compile Include="..\MiaoNet.Client\Misc\PFormat.cs" LinkBase="0-Shared" />
     <Compile Include="..\MiaoNet.ClientShared\ConnectionLifecycleCoordinator.cs" LinkBase="0-Shared" />
+    <Compile Include="..\MiaoNet.Client\Misc\AvatarDownloadPolicy.cs" LinkBase="0-Shared" />
     <Compile Include="..\MiaoNet.Shared\SafeGuard.cs" LinkBase="0-Shared/Command" />
     <Compile Include="..\ChatInputBox\ChatInputBox\ChatText*.cs" LinkBase="0-Shared/ChatInputBox" />
   </ItemGroup>


### PR DESCRIPTION
## 基线

- #43 和 #44 已合并。
- 本分支已 rebase 到最新 `wip`，并保留前置改动与头像策略测试。

## 问题

头像 URL 来自远端玩家资料，属于不可信输入。

原实现直接使用默认 `HttpClient` 下载该 URL，没有限制：

- URL scheme；
- URL 中的用户名和密码；
- 目标 IP 地址；
- HTTP 重定向目标；
- 系统代理；
- 下载内容大小；
- 图片像素尺寸；
- 连接和总请求时间。

这会带来以下风险。

### SSRF

远端玩家可以将头像 URL 设置为：

- localhost；
- 私有网络地址；
- 链路本地地址；
- 云服务 metadata 地址；
- 其他仅客户端本机可访问的 HTTP 服务。

客户端加载头像时会主动访问该地址。

### 重定向绕过

即使初始 URL 指向正常公网 HTTPS 地址，默认 `HttpClient` 仍可能自动跟随重定向到：

- HTTP 地址；
- localhost；
- 私有网络；
- 链路本地地址。

只验证初始 URL 无法阻止这种绕过。

### DNS rebinding

如果只在发起请求前解析并验证 DNS，攻击者可以让验证阶段和实际连接阶段得到不同地址，将后续连接指向私网。

### 资源消耗

原实现使用 `ReadAsByteArrayAsync` 一次性读取完整响应，没有下载上限。

远端可以返回很大的文件，增加：

- 内存占用；
- 磁盘占用；
- GC 压力；
- 图片解码开销。

即使文件本身较小，压缩图片也可能声明很大的像素尺寸，造成解码和纹理资源压力。

## 原因

头像下载沿用了普通可信 HTTP 资源的处理方式，但 URL 实际由远端玩家控制。

默认 `HttpClientHandler` 的自动重定向、代理和 DNS 连接行为无法保证每个实际连接目标都经过 MiaoNet 的地址策略校验。

## 修改

### URL 策略

头像 URL 必须满足：

- 是绝对 URL；
- scheme 为 HTTPS；
- 不包含用户名或密码。

以下 URL 会被拒绝：

- HTTP；
- file；
- 相对 URL；
- 包含 `user:password@host` 的 URL。

### 地址策略

DNS 解析结果必须是允许的公网地址。

拒绝的 IPv4 地址包括：

- `0.0.0.0/8`；
- `10.0.0.0/8`；
- `100.64.0.0/10`；
- `127.0.0.0/8`；
- `169.254.0.0/16`；
- `172.16.0.0/12`；
- `192.168.0.0/16`；
- 文档和基准测试保留地址；
- multicast 和其他高位特殊地址。

拒绝的 IPv6 地址包括：

- loopback；
- link-local；
- site-local；
- unique-local；
- multicast；
- unspecified；
- IPv6 文档保留地址。

IPv4-mapped IPv6 地址会先转换为 IPv4，再执行相同检查。

### 连接过程

使用自定义 `SocketsHttpHandler`：

- `AllowAutoRedirect=false`；
- `UseProxy=false`；
- 连接超时 10 秒；
- 总请求超时 20 秒；
- 使用自定义 `ConnectCallback`。

`ConnectCallback` 在真正创建 socket 时：

1. 解析目标主机；
2. 过滤所有非公网地址；
3. 只尝试连接通过检查的地址；
4. 不把未验证地址交回默认连接逻辑。

TLS 仍然使用原始 hostname，保留正常的 SNI 和证书主机名验证。

### 重定向

手动处理以下重定向状态：

- 301；
- 302；
- 303；
- 307；
- 308。

每次重定向都会重新验证：

- HTTPS；
- URL 凭据；
- DNS；
- 实际连接 IP。

最多允许 3 次重定向。

缺少 Location 或超过重定向上限时拒绝下载。

### 下载大小

头像响应最大允许 2 MiB。

同时检查：

- `Content-Length`；
- 实际流式读取的累计字节数。

即使服务端没有提供 Content-Length，或者提供错误的较小值，实际读取超过 2 MiB 时也会立即失败。

### 图片尺寸与格式

下载完成后读取 PNG header，并要求：

```text
0 < width <= 2048
0 < height <= 2048
```

不是有效 PNG、尺寸无效或超过限制的图片不会写入最终缓存。

### 缓存写入

- 先写入临时文件；
- 完整下载并验证后再原子替换缓存文件；
- 下载失败时不会留下被误认为有效头像的部分文件；
- HTTP response 和内容流都会及时释放。

## 行为变化

以下此前可能被接受的头像现在会被拒绝：

- HTTP 头像；
- 带 URL 用户名或密码的头像；
- 指向本机或私网的头像；
- 通过重定向进入非公网地址的头像；
- 超过 2 MiB 的头像；
- 宽或高超过 2048 的头像；
- 无法识别格式的文件。

合法的公网 HTTPS PNG 头像保持支持；GIF 和 JPEG 会被拒绝。

头像下载失败时，客户端继续使用现有的缺失头像回退逻辑，不会因此断开 MiaoNet 连接。

## 验证

新增头像下载策略测试，覆盖：

- 允许无凭据 HTTPS URL；
- 拒绝 HTTP URL；
- 拒绝带用户名密码的 HTTPS URL；
- 拒绝 file URL；
- 拒绝以下非公网地址：
  - 127.0.0.1；
  - 10.0.0.1；
  - 172.16.0.1；
  - 192.168.1.1；
  - 169.254.1.1；
  - 100.64.0.1；
  - ::1；
- 允许以下公网地址：
  - 1.1.1.1；
  - 8.8.8.8；
- 头像下载策略测试：15/15 通过；
- Debug/Release 完整单元测试：157/157 通过；
- Debug/Release 完整解决方案构建通过；
- Client、MockClient、Server 均成功构建；
- `git diff --check` 通过。

当前自动化测试覆盖 URL、IP、PNG 尺寸策略，以及对 GIF/JPEG 的拒绝。

以下实现已经完成并通过编译及组合验证，但尚未分别建立直接单元测试：

- 重定向链；
- 流式下载大小上限；
- `ConnectCallback` 的 DNS rebinding 防护；
- 临时文件与原子缓存替换。