### PR TITLE
fix(server): 安全释放热更新后的旧证书

### DIFF
--- a/source/MiaoNet.Server/Properties/AssemblyInfo.cs
+++ b/source/MiaoNet.Server/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MiaoNet.UnitTest")]

--- a/source/MiaoNet.Server/Server/Certificate/IMiaoCertificateService.cs
+++ b/source/MiaoNet.Server/Server/Certificate/IMiaoCertificateService.cs
@@ -1,8 +1,6 @@
-﻿using System.Security.Cryptography.X509Certificates;
-
 namespace MiaoNet.Server;
 
 public interface IMiaoCertificateService
 {
-    public X509Certificate2 GetCertificate();
+    public MiaoCertificateLease AcquireCertificate();
 }

--- a/source/MiaoNet.Server/Server/Certificate/LocalMiaoCertificateService.cs
+++ b/source/MiaoNet.Server/Server/Certificate/LocalMiaoCertificateService.cs
@@ -1,19 +1,22 @@
-﻿using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MiaoNet.Server;
 
-public sealed class LocalMiaoCertificateService : IMiaoCertificateService
+public sealed class LocalMiaoCertificateService : IMiaoCertificateService, IDisposable
 {
-    private readonly X509Certificate2 cert;
+    private readonly ReloadableResource<X509Certificate2> certificates;
 
     public LocalMiaoCertificateService()
     {
         using var certStream = typeof(MiaoCertificateService).Assembly.GetManifestResourceStream("localhost.pfx")!;
         byte[] certRawData = new byte[certStream.Length];
         certStream.ReadExactly(certRawData, 0, certRawData.Length);
-        cert = X509CertificateLoader.LoadPkcs12(certRawData, null);
+        certificates = new ReloadableResource<X509Certificate2>(X509CertificateLoader.LoadPkcs12(certRawData, null));
     }
 
-    public X509Certificate2 GetCertificate() 
-        => cert;
+    public MiaoCertificateLease AcquireCertificate()
+        => new(certificates.Acquire());
+
+    public void Dispose()
+        => certificates.Dispose();
 }

--- a/source/MiaoNet.Server/Server/Certificate/MiaoCertificateLease.cs
+++ b/source/MiaoNet.Server/Server/Certificate/MiaoCertificateLease.cs
@@ -1,0 +1,16 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace MiaoNet.Server;
+
+public sealed class MiaoCertificateLease : IDisposable
+{
+    private readonly ResourceLease<X509Certificate2> lease;
+
+    internal MiaoCertificateLease(ResourceLease<X509Certificate2> lease)
+        => this.lease = lease;
+
+    public X509Certificate2 Certificate => lease.Value;
+
+    public void Dispose()
+        => lease.Dispose();
+}

--- a/source/MiaoNet.Server/Server/Certificate/MiaoCertificateService.cs
+++ b/source/MiaoNet.Server/Server/Certificate/MiaoCertificateService.cs
@@ -1,5 +1,3 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -10,15 +8,13 @@ namespace MiaoNet.Server;
 public sealed class MiaoCertificateService : BackgroundService, IMiaoCertificateService
 {
     private readonly ILogger<MiaoCertificateService> logger;
-
     private readonly PeriodicTimer timer;
+    private readonly ReloadableResource<X509Certificate2> certificates;
 
     private readonly string certPath;
     private readonly string keyPath;
     private DateTime lastCertModifiedTime;
     private DateTime lastKeyModifiedTime;
-
-    private volatile X509Certificate2 cert;
 
     public MiaoCertificateService(ILogger<MiaoCertificateService> logger, IOptions<MiaoServerOptions> options)
     {
@@ -29,42 +25,50 @@ public sealed class MiaoCertificateService : BackgroundService, IMiaoCertificate
         }
         certPath = oc.CertificatePath;
         keyPath = oc.CertificateKeyPath;
-        timer = new PeriodicTimer(TimeSpan.FromHours(4));
         this.logger = logger;
         lastCertModifiedTime = File.GetLastWriteTimeUtc(certPath);
         lastKeyModifiedTime = File.GetLastWriteTimeUtc(keyPath);
-        Reload();
+        certificates = new ReloadableResource<X509Certificate2>(LoadCertificate());
+        timer = new PeriodicTimer(TimeSpan.FromHours(4));
     }
 
-    [MemberNotNull(nameof(cert))]
-    private void Reload()
+    private X509Certificate2 LoadCertificate()
     {
         logger.LogInformation(AppEvents.Certificate, "Reloading certificate...");
         var newCert = X509Certificate2.CreateFromPemFile(certPath, keyPath);
-        cert = newCert;
         logger.LogInformation(
             AppEvents.Certificate,
             "Reloaded, not before: {a}, not after: {b}, name: {c}.",
-            cert.NotBefore,
-            cert.NotAfter,
-            cert.SubjectName.Name
+            newCert.NotBefore,
+            newCert.NotAfter,
+            newCert.SubjectName.Name
         );
+        return newCert;
     }
 
-    public X509Certificate2 GetCertificate()
-        => cert;
+    public MiaoCertificateLease AcquireCertificate()
+        => new(certificates.Acquire());
 
     private void CheckAndReload()
     {
         logger.LogInformation(AppEvents.Certificate, "Check if certificate is reload needed...");
         var certModifiedTime = File.GetLastWriteTimeUtc(certPath);
-        var KeyModifiedTime = File.GetLastWriteTimeUtc(keyPath);
-        if (lastCertModifiedTime != certModifiedTime || lastKeyModifiedTime != KeyModifiedTime)
+        var keyModifiedTime = File.GetLastWriteTimeUtc(keyPath);
+        if (lastCertModifiedTime != certModifiedTime || lastKeyModifiedTime != keyModifiedTime)
         {
-            logger.LogInformation(AppEvents.Certificate, "Certificate modified: cert: {cd}, key: {kd}.", certModifiedTime, KeyModifiedTime);
+            logger.LogInformation(AppEvents.Certificate, "Certificate modified: cert: {cd}, key: {kd}.", certModifiedTime, keyModifiedTime);
             lastCertModifiedTime = certModifiedTime;
-            lastKeyModifiedTime = KeyModifiedTime;
-            Reload();
+            lastKeyModifiedTime = keyModifiedTime;
+            var newCertificate = LoadCertificate();
+            try
+            {
+                certificates.Replace(newCertificate);
+            }
+            catch
+            {
+                newCertificate.Dispose();
+                throw;
+            }
         }
         else
         {
@@ -76,5 +80,12 @@ public sealed class MiaoCertificateService : BackgroundService, IMiaoCertificate
     {
         while (await timer.WaitForNextTickAsync(stoppingToken))
             CheckAndReload();
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        timer.Dispose();
+        certificates.Dispose();
     }
 }

--- a/source/MiaoNet.Server/Server/Certificate/ReloadableResource.cs
+++ b/source/MiaoNet.Server/Server/Certificate/ReloadableResource.cs
@@ -1,0 +1,93 @@
+namespace MiaoNet.Server;
+
+internal sealed class ReloadableResource<T> : IDisposable where T : class, IDisposable
+{
+    private readonly object gate = new();
+    private Entry? current;
+    private bool disposed;
+
+    public ReloadableResource(T initialValue)
+    {
+        ArgumentNullException.ThrowIfNull(initialValue);
+        current = new Entry(initialValue);
+    }
+
+    public ResourceLease<T> Acquire()
+    {
+        lock (gate)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            var entry = current!;
+            entry.LeaseCount++;
+            return new ResourceLease<T>(entry.Value, () => Release(entry));
+        }
+    }
+
+    public void Replace(T value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        Entry? entryToDispose;
+        lock (gate)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            var previous = current!;
+            current = new Entry(value);
+            entryToDispose = Retire(previous);
+        }
+
+        entryToDispose?.Value.Dispose();
+    }
+
+    public void Dispose()
+    {
+        Entry? entryToDispose;
+        lock (gate)
+        {
+            if (disposed)
+                return;
+
+            disposed = true;
+            entryToDispose = Retire(current!);
+            current = null;
+        }
+
+        entryToDispose?.Value.Dispose();
+    }
+
+    private void Release(Entry entry)
+    {
+        bool shouldDispose;
+        lock (gate)
+        {
+            entry.LeaseCount--;
+            shouldDispose = entry.Retired && entry.LeaseCount == 0;
+        }
+
+        if (shouldDispose)
+            entry.Value.Dispose();
+    }
+
+    private static Entry? Retire(Entry entry)
+    {
+        entry.Retired = true;
+        return entry.LeaseCount == 0 ? entry : null;
+    }
+
+    private sealed class Entry(T value)
+    {
+        public T Value { get; } = value;
+        public int LeaseCount { get; set; }
+        public bool Retired { get; set; }
+    }
+}
+
+internal sealed class ResourceLease<T>(T value, Action release) : IDisposable where T : class, IDisposable
+{
+    private Action? release = release;
+
+    public T Value { get; } = value;
+
+    public void Dispose()
+        => Interlocked.Exchange(ref release, null)?.Invoke();
+}

--- a/source/MiaoNet.Server/Server/Connection/TlsTcpPendingConnection.cs
+++ b/source/MiaoNet.Server/Server/Connection/TlsTcpPendingConnection.cs
@@ -46,9 +46,10 @@ public sealed class TlsTcpPendingConnection : IPendingNetworkConnection
         SslStream sslStream = new SslStream(networkStream);
         try
         {
+            using var certificateLease = certificateService.AcquireCertificate();
             SslServerAuthenticationOptions options = new()
             {
-                ServerCertificate = certificateService.GetCertificate(),
+                ServerCertificate = certificateLease.Certificate,
                 EnabledSslProtocols = Connection.AllowedSslProtocols,
                 // no need to check server-side
                 CertificateRevocationCheckMode = X509RevocationMode.NoCheck

--- a/source/MiaoNet.UnitTest/ReloadableResourceTests.cs
+++ b/source/MiaoNet.UnitTest/ReloadableResourceTests.cs
@@ -1,0 +1,85 @@
+namespace MiaoNet.Server;
+
+[TestClass]
+public sealed class ReloadableResourceTests
+{
+    [TestMethod]
+    public void ReplaceKeepsLeasedResourceAliveUntilLeaseIsReleased()
+    {
+        DisposableResource first = new();
+        DisposableResource second = new();
+        using ReloadableResource<DisposableResource> resources = new(first);
+        var lease = resources.Acquire();
+
+        resources.Replace(second);
+
+        Assert.IsFalse(first.IsDisposed);
+        Assert.AreSame(first, lease.Value);
+
+        lease.Dispose();
+
+        Assert.IsTrue(first.IsDisposed);
+        Assert.IsFalse(second.IsDisposed);
+    }
+
+    [TestMethod]
+    public void ReplaceImmediatelyDisposesUnleasedResource()
+    {
+        DisposableResource first = new();
+        DisposableResource second = new();
+        using ReloadableResource<DisposableResource> resources = new(first);
+
+        resources.Replace(second);
+
+        Assert.IsTrue(first.IsDisposed);
+        Assert.IsFalse(second.IsDisposed);
+    }
+
+    [TestMethod]
+    public void RetiredResourceWaitsForEveryOutstandingLease()
+    {
+        DisposableResource first = new();
+        DisposableResource second = new();
+        using ReloadableResource<DisposableResource> resources = new(first);
+        var firstLease = resources.Acquire();
+        var secondLease = resources.Acquire();
+
+        resources.Replace(second);
+        firstLease.Dispose();
+
+        Assert.IsFalse(first.IsDisposed);
+
+        secondLease.Dispose();
+
+        Assert.IsTrue(first.IsDisposed);
+        Assert.AreEqual(1, first.DisposeCount);
+    }
+
+    [TestMethod]
+    public void StoreDisposalWaitsForOutstandingLeaseAndRejectsNewOnes()
+    {
+        DisposableResource resource = new();
+        ReloadableResource<DisposableResource> resources = new(resource);
+        var lease = resources.Acquire();
+
+        resources.Dispose();
+
+        Assert.IsFalse(resource.IsDisposed);
+        Assert.Throws<ObjectDisposedException>(() => resources.Acquire());
+
+        lease.Dispose();
+        lease.Dispose();
+
+        Assert.IsTrue(resource.IsDisposed);
+        Assert.AreEqual(1, resource.DisposeCount);
+    }
+
+    private sealed class DisposableResource : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+        public bool IsDisposed => DisposeCount != 0;
+
+        public void Dispose()
+            => DisposeCount++;
+    }
+}


### PR DESCRIPTION
## 前置 PR

- 在 #41 后合并。
- 本 PR 与 #41 都会新增 `MiaoNet.Server/Properties/AssemblyInfo.cs`。
- #41 合并后，本分支需要 rebase 到最新 `wip`。
- 解决冲突时，应只保留一条：
  ```csharp
  [assembly: InternalsVisibleTo("MiaoNet.UnitTest")]
  ```
- rebase 后需要重新执行完整单元测试和服务端构建。

## 问题

`MiaoCertificateService` 每 4 小时检查证书文件是否发生变化。

检测到变化后，原实现会加载新的 `X509Certificate2` 并直接覆盖当前证书引用，但不会释放被替换的旧证书。

`X509Certificate2` 持有原生加密资源。服务长期运行并多次更新证书后，未释放的旧实例会持续占用原生句柄和相关内存。

同时，不能在替换证书时直接调用旧证书的 `Dispose()`。TLS 握手是异步操作，证书热更新可能与正在进行的 `AuthenticateAsServerAsync` 并发：

1. TLS 连接取得当前证书；
2. 后台服务加载并替换证书；
3. 后台服务立即释放旧证书；
4. 尚未完成的 TLS 握手继续访问已释放的证书。

这可能导致握手异常或依赖平台实现的不稳定行为。

## 原因

原证书服务通过 `GetCertificate()` 返回裸 `X509Certificate2`：

```csharp
X509Certificate2 GetCertificate();
```

该接口没有表达证书的使用期，服务无法判断返回的证书是否仍被某个 TLS 握手使用。

因此，原实现只能替换引用，既无法安全地立即释放旧证书，也无法获知稍后何时可以释放。

## 修改

### 可热替换资源

新增内部通用资源容器：

```csharp
ReloadableResource<T>
```

容器负责：

- 保存当前资源；
- 为每次使用创建租约；
- 记录每个资源的活动租约数量；
- 原子替换当前资源；
- 将旧资源标记为不再使用；
- 在旧资源没有活动租约后调用 `Dispose()`；
- 容器关闭后拒绝创建新租约。

资源替换时：

- 如果旧资源没有活动租约，立即释放；
- 如果旧资源仍被使用，延迟到最后一个租约释放后再释放。

资源释放发生在同步锁之外，避免在执行外部 `Dispose()` 逻辑时占用容器锁。

### 证书租约

新增：

```csharp
MiaoCertificateLease
```

并将证书服务接口从：

```csharp
X509Certificate2 GetCertificate();
```

改为：

```csharp
MiaoCertificateLease AcquireCertificate();
```

租约提供当前证书，并通过 `Dispose()` 通知资源容器本次使用已经结束。

租约释放是幂等的。重复调用 `Dispose()` 不会重复减少引用计数，也不会重复释放证书。

### TLS 握手生命周期

`TlsTcpPendingConnection` 在开始 TLS 握手前获取证书租约：

```csharp
using var certificateLease = certificateService.AcquireCertificate();
```

租约覆盖整个：

```csharp
AuthenticateAsServerAsync(...)
```

调用。

因此，即使后台服务在握手期间更新证书：

- 新连接可以取得新证书；
- 已开始的握手继续安全使用旧证书；
- 旧证书会在相关握手全部结束后释放。

### 证书热更新

`MiaoCertificateService` 在检测到证书文件变化后：

1. 加载新的证书；
2. 原子替换当前证书；
3. 将旧证书交给租约容器管理；
4. 在安全时机释放旧证书。

如果替换新证书失败，新加载的证书也会被立即释放，不会产生新的资源泄漏。

原有的证书文件检查和 4 小时刷新间隔保持不变。

### 服务关闭

`MiaoCertificateService.Dispose()` 现在会释放：

- `BackgroundService` 自身资源；
- `PeriodicTimer`；
- 当前证书资源容器。

服务关闭后：

- 不再允许获取新的证书租约；
- 没有被使用的当前证书会立即释放；
- 正在被 TLS 握手使用的证书会等待相应租约结束后释放。

### 本地证书服务

`LocalMiaoCertificateService` 同样改为使用证书租约，并实现 `IDisposable`。

嵌入的本地开发证书会在服务释放时正确释放，同时与正式证书服务保持相同的生命周期语义。

## 行为变化

- 证书刷新间隔仍为 4 小时。
- 证书文件路径和加载方式保持不变。
- TLS 协议配置和证书验证行为保持不变。
- 正在进行的 TLS 握手不会因证书热更新而失去其证书实例。
- 被替换的证书会在不再使用后及时释放。
- 服务关闭后不再允许获取新的证书。
- 不改变 MiaoNet 网络协议或客户端行为。

`IMiaoCertificateService` 的方法签名发生变化，但该接口用于服务端内部证书注入；仓库内调用方已经同步更新。

## 验证

新增 4 项 `ReloadableResource` 生命周期测试，覆盖：

- 替换资源时，有活动租约的旧资源不会提前释放；
- 替换资源时，没有活动租约的旧资源会立即释放；
- 存在多个租约时，必须等待全部租约释放；
- 资源容器关闭后：
  - 拒绝获取新租约；
  - 等待已有租约结束；
  - 最终只释放资源一次；
  - 租约可以重复安全释放。

验证结果：

- 新增资源生命周期测试：4/4 通过；
- 完整单元测试：94/94 通过；
- 完整 Debug 解决方案构建通过：
  - 0 个警告；
  - 0 个错误；
- `git diff --check` 通过。

当前测试通过确定性的资源租约模型覆盖并发生命周期边界；尚未增加真实 TLS 连接与证书文件热更新同时发生的端到端测试。
