### PR TITLE
refactor(server): Use `MoveResult` for broadcast target selection.

### DIFF
--- a/source/MiaoNet.Server/Data/MoveResult.cs
+++ b/source/MiaoNet.Server/Data/MoveResult.cs
@@ -1,0 +1,13 @@
+namespace MiaoNet.Server;
+
+public class MoveResult
+{
+    public ScopeTuple From;
+    public ScopeTuple To;
+
+    public MoveResult(ScopeTuple from, ScopeTuple to)
+    {
+        this.From = from;
+        this.To = to;
+    }
+}

--- a/source/MiaoNet.Server/Data/ScopeTuple.cs
+++ b/source/MiaoNet.Server/Data/ScopeTuple.cs
@@ -1,0 +1,15 @@
+namespace MiaoNet.Server;
+
+public class ScopeTuple
+{
+    public ServerChannel? Channel;
+    public ServerMap? Map;
+    public ServerRoom? Room;
+
+    public ScopeTuple(ServerChannel? channel, ServerMap? map, ServerRoom? room = null)
+    {
+        this.Channel = channel;
+        this.Map = map;
+        this.Room = room;
+    }
+}

--- a/source/MiaoNet.Server/Data/ServerChannel.cs
+++ b/source/MiaoNet.Server/Data/ServerChannel.cs
@@ -71,13 +71,14 @@ public sealed class ServerChannel : IPlayerScope
         }
         else
         {
-            map = new ServerMap(to, connection);
+            ServerMap mapNew = new(to, connection);
             bool result = ImmutableInterlocked.Update(
                 ref maps,
-                (d, c) => d.Add(c.map.MapLocation, c.map),
-                (connection, map)
+                (d, c) => d.Add(c.mapNew.MapLocation, c.mapNew),
+                (connection, mapNew)
             );
             Debug.Assert(result);
+            map = mapNew;
         }
         return map;
     }

--- a/source/MiaoNet.Server/Data/ServerChannel.cs
+++ b/source/MiaoNet.Server/Data/ServerChannel.cs
@@ -57,7 +57,6 @@ public sealed class ServerChannel : IPlayerScope
         {
             bool result = ImmutableInterlocked.Update(ref maps, (d, u) => d.Remove(u.MapLocation), oldMap);
             Debug.Assert(result);
-            oldMap.Dispose();
         }
     }
 
@@ -88,8 +87,8 @@ public sealed class ServerChannel : IPlayerScope
         bool result = ImmutableInterlocked.Update(ref players, (d, c) => d.Remove(c), connection);
         Debug.Assert(result);
 
-        var mapLoc = connection.Player.Location.Map;
-        OnPlayerMapMoveFrom(connection, mapLoc);
+        var map = connection.Player.Location.Map;
+        OnPlayerMapMoveFrom(connection, map);
         connection.Player.Scope.Map = null;
     }
 }

--- a/source/MiaoNet.Server/Data/ServerChannel.cs
+++ b/source/MiaoNet.Server/Data/ServerChannel.cs
@@ -93,6 +93,5 @@ public sealed class ServerChannel : IPlayerScope
 
         var mapLoc = connection.Player.Location.Map;
         OnPlayerMapMoveFrom(connection, mapLoc);
-        connection.Player.Scope = default;
     }
 }

--- a/source/MiaoNet.Server/Data/ServerChannel.cs
+++ b/source/MiaoNet.Server/Data/ServerChannel.cs
@@ -17,6 +17,8 @@ public sealed class ServerChannel : IPlayerScope
 
     IEnumerable<MiaoClientConnection> IPlayerScope.Players => players;
 
+    public IEnumerable<MiaoClientConnection> AllPlayers => players;
+
     public ImmutableDictionary<PlayerMapLocation, ServerMap> Maps => maps;
 
     public ServerChannel(int id, ChannelInfo info)
@@ -32,14 +34,19 @@ public sealed class ServerChannel : IPlayerScope
         bool result = ImmutableInterlocked.Update(ref players, (d, c) => d.Add(c), connection);
         Debug.Assert(result);
 
-        var map = connection.Player.Location.Map;
-        OnPlayerMapMoveTo(connection, map);
+        var mapLoc = connection.Player.Location.Map;
+        var mapScope = OnPlayerMapMoveTo(connection, mapLoc);
+        connection.Player.Scope = new ScopeTuple(this, mapScope);
     }
 
-    public void OnPlayerMapMove(MiaoClientConnection connection, PlayerMapLocation from, PlayerMapLocation to)
+    public MoveResult OnPlayerMapMove(MiaoClientConnection connection, PlayerMapLocation to)
     {
+        var from = connection.Player.Location.Map;
+        var fromScope = connection.Player.Scope;
         OnPlayerMapMoveFrom(connection, from);
-        OnPlayerMapMoveTo(connection, to);
+        var mapScope = OnPlayerMapMoveTo(connection, to);
+        connection.Player.Scope.Map = mapScope;
+        return new MoveResult(fromScope, connection.Player.Scope);
     }
 
     private void OnPlayerMapMoveFrom(MiaoClientConnection connection, PlayerMapLocation from)
@@ -53,13 +60,14 @@ public sealed class ServerChannel : IPlayerScope
         {
             bool result = ImmutableInterlocked.Update(ref maps, (d, u) => d.Remove(u.MapLocation), oldMap);
             Debug.Assert(result);
+            oldMap.Dispose();
         }
     }
 
-    private void OnPlayerMapMoveTo(MiaoClientConnection connection, PlayerMapLocation to)
+    private ServerMap? OnPlayerMapMoveTo(MiaoClientConnection connection, PlayerMapLocation to)
     {
         if (to.IsEmpty)
-            return;
+            return null;
 
         if (maps.TryGetValue(to, out var map))
         {
@@ -67,14 +75,15 @@ public sealed class ServerChannel : IPlayerScope
         }
         else
         {
-            ServerMap mapNew = new(to, connection);
+            map = new ServerMap(to, connection);
             bool result = ImmutableInterlocked.Update(
                 ref maps,
-                (d, c) => d.Add(c.mapNew.MapLocation, c.mapNew),
-                (connection, mapNew)
+                (d, c) => d.Add(c.map.MapLocation, c.map),
+                (connection, map)
             );
             Debug.Assert(result);
         }
+        return map;
     }
 
     public void OnRemovePlayer(MiaoClientConnection connection)
@@ -82,7 +91,8 @@ public sealed class ServerChannel : IPlayerScope
         bool result = ImmutableInterlocked.Update(ref players, (d, c) => d.Remove(c), connection);
         Debug.Assert(result);
 
-        var map = connection.Player.Location.Map;
-        OnPlayerMapMoveFrom(connection, map);
+        var mapLoc = connection.Player.Location.Map;
+        OnPlayerMapMoveFrom(connection, mapLoc);
+        connection.Player.Scope = default;
     }
 }

--- a/source/MiaoNet.Server/Data/ServerChannel.cs
+++ b/source/MiaoNet.Server/Data/ServerChannel.cs
@@ -17,8 +17,6 @@ public sealed class ServerChannel : IPlayerScope
 
     IEnumerable<MiaoClientConnection> IPlayerScope.Players => players;
 
-    public IEnumerable<MiaoClientConnection> AllPlayers => players;
-
     public ImmutableDictionary<PlayerMapLocation, ServerMap> Maps => maps;
 
     public ServerChannel(int id, ChannelInfo info)
@@ -35,8 +33,7 @@ public sealed class ServerChannel : IPlayerScope
         Debug.Assert(result);
 
         var mapLoc = connection.Player.Location.Map;
-        var mapScope = OnPlayerMapMoveTo(connection, mapLoc);
-        connection.Player.Scope = new ScopeTuple(this, mapScope);
+        OnPlayerMapMoveTo(connection, mapLoc);
     }
 
     public MoveResult OnPlayerMapMove(MiaoClientConnection connection, PlayerMapLocation to)
@@ -93,5 +90,6 @@ public sealed class ServerChannel : IPlayerScope
 
         var mapLoc = connection.Player.Location.Map;
         OnPlayerMapMoveFrom(connection, mapLoc);
+        connection.Player.Scope.Map = null;
     }
 }

--- a/source/MiaoNet.Server/Data/ServerMap.cs
+++ b/source/MiaoNet.Server/Data/ServerMap.cs
@@ -4,7 +4,7 @@ using MiaoNet.Shared;
 
 namespace MiaoNet.Server;
 
-public sealed class ServerMap : IPlayerScope, IDisposable
+public sealed class ServerMap : IPlayerScope
 {
     private ImmutableHashSet<MiaoClientConnection> players;
 
@@ -49,10 +49,5 @@ public sealed class ServerMap : IPlayerScope, IDisposable
             list.Add(new PlayerMovedInitialDataWithID(p.ID, new PlayerMovedInitialData(p.State!.Clone())));
         }
         return list;
-    }
-
-    public void Dispose()
-    {
-        StateLock.Dispose();
     }
 }

--- a/source/MiaoNet.Server/Data/ServerMap.cs
+++ b/source/MiaoNet.Server/Data/ServerMap.cs
@@ -1,14 +1,15 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Threading.Channels;
 using MiaoNet.Shared;
 
 namespace MiaoNet.Server;
 
-public sealed class ServerMap : IPlayerScope
+public sealed class ServerMap : IPlayerScope, IDisposable
 {
     private ImmutableHashSet<MiaoClientConnection> players;
-
-    public ReaderWriterLockSlim StateLock { get; }
+    private readonly Channel<Func<Task>> workQueue;
+    private readonly Task consumer;
 
     public PlayerMapLocation MapLocation { get; }
 
@@ -20,7 +21,29 @@ public sealed class ServerMap : IPlayerScope
     {
         players = ImmutableHashSet<MiaoClientConnection>.Empty.Add(connection);
         MapLocation = mapLocation;
-        StateLock = new();
+
+        workQueue = Channel.CreateUnbounded<Func<Task>>(new() { SingleReader = true });
+        consumer = ConsumeAsync();
+    }
+
+    public ValueTask PostAsync(Func<Task> work)
+        => workQueue.Writer.WriteAsync(work);
+
+    public async Task<T> PostAsync<T>(Func<T> work)
+    {
+        var tcs = new TaskCompletionSource<T>();
+        await workQueue.Writer.WriteAsync(() =>
+        {
+            tcs.SetResult(work());
+            return Task.CompletedTask;
+        });
+        return await tcs.Task;
+    }
+
+    private async Task ConsumeAsync()
+    {
+        await foreach (var work in workQueue.Reader.ReadAllAsync())
+            await work();
     }
 
     public void OnAddPlayer(MiaoClientConnection connection)
@@ -37,17 +60,20 @@ public sealed class ServerMap : IPlayerScope
 
     public IReadOnlyCollection<PlayerMovedInitialDataWithID> GetPlayerMovedInitialDatas(MiaoClientConnection except)
     {
-        Debug.Assert(StateLock.IsWriteLockHeld);
-
         var list = new List<PlayerMovedInitialDataWithID>(players.Count);
         foreach (var con in players)
         {
             var p = con.Player;
-            // players that in debug map can cause null state
             if (con == except || p.State is null)
                 continue;
             list.Add(new PlayerMovedInitialDataWithID(p.ID, new PlayerMovedInitialData(p.State!.Clone())));
         }
         return list;
+    }
+
+    public void Dispose()
+    {
+        workQueue.Writer.Complete();
+        consumer.Wait();
     }
 }

--- a/source/MiaoNet.Server/Data/ServerMap.cs
+++ b/source/MiaoNet.Server/Data/ServerMap.cs
@@ -58,17 +58,21 @@ public sealed class ServerMap : IPlayerScope, IDisposable
         Debug.Assert(result);
     }
 
-    public IReadOnlyCollection<PlayerMovedInitialDataWithID> GetPlayerMovedInitialDatas(MiaoClientConnection except)
+    public Task<IReadOnlyCollection<PlayerMovedInitialDataWithID>> GetPlayerMovedInitialDatasAsync(MiaoClientConnection except)
     {
-        var list = new List<PlayerMovedInitialDataWithID>(players.Count);
-        foreach (var con in players)
+        return PostAsync(() =>
         {
-            var p = con.Player;
-            if (con == except || p.State is null)
-                continue;
-            list.Add(new PlayerMovedInitialDataWithID(p.ID, new PlayerMovedInitialData(p.State!.Clone())));
-        }
-        return list;
+            var list = new List<PlayerMovedInitialDataWithID>(players.Count);
+            foreach (var con in players)
+            {
+                var p = con.Player;
+                // players that in debug map can cause null state
+                if (con == except || p.State is null)
+                    continue;
+                list.Add(new PlayerMovedInitialDataWithID(p.ID, new PlayerMovedInitialData(p.State!.Clone())));
+            }
+            return (IReadOnlyCollection<PlayerMovedInitialDataWithID>)list;
+        });
     }
 
     public void Dispose()

--- a/source/MiaoNet.Server/Data/ServerMap.cs
+++ b/source/MiaoNet.Server/Data/ServerMap.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Threading.Channels;
 using MiaoNet.Shared;
 
 namespace MiaoNet.Server;
@@ -8,8 +7,8 @@ namespace MiaoNet.Server;
 public sealed class ServerMap : IPlayerScope, IDisposable
 {
     private ImmutableHashSet<MiaoClientConnection> players;
-    private readonly Channel<Func<Task>> workQueue;
-    private readonly Task consumer;
+
+    public ReaderWriterLockSlim StateLock { get; }
 
     public PlayerMapLocation MapLocation { get; }
 
@@ -21,29 +20,7 @@ public sealed class ServerMap : IPlayerScope, IDisposable
     {
         players = ImmutableHashSet<MiaoClientConnection>.Empty.Add(connection);
         MapLocation = mapLocation;
-
-        workQueue = Channel.CreateUnbounded<Func<Task>>(new() { SingleReader = true });
-        consumer = ConsumeAsync();
-    }
-
-    public ValueTask PostAsync(Func<Task> work)
-        => workQueue.Writer.WriteAsync(work);
-
-    public async Task<T> PostAsync<T>(Func<T> work)
-    {
-        var tcs = new TaskCompletionSource<T>();
-        await workQueue.Writer.WriteAsync(() =>
-        {
-            tcs.SetResult(work());
-            return Task.CompletedTask;
-        });
-        return await tcs.Task;
-    }
-
-    private async Task ConsumeAsync()
-    {
-        await foreach (var work in workQueue.Reader.ReadAllAsync())
-            await work();
+        StateLock = new();
     }
 
     public void OnAddPlayer(MiaoClientConnection connection)
@@ -58,26 +35,24 @@ public sealed class ServerMap : IPlayerScope, IDisposable
         Debug.Assert(result);
     }
 
-    public Task<IReadOnlyCollection<PlayerMovedInitialDataWithID>> GetPlayerMovedInitialDatasAsync(MiaoClientConnection except)
+    public IReadOnlyCollection<PlayerMovedInitialDataWithID> GetPlayerMovedInitialDatas(MiaoClientConnection except)
     {
-        return PostAsync(() =>
+        Debug.Assert(StateLock.IsWriteLockHeld);
+
+        var list = new List<PlayerMovedInitialDataWithID>(players.Count);
+        foreach (var con in players)
         {
-            var list = new List<PlayerMovedInitialDataWithID>(players.Count);
-            foreach (var con in players)
-            {
-                var p = con.Player;
-                // players that in debug map can cause null state
-                if (con == except || p.State is null)
-                    continue;
-                list.Add(new PlayerMovedInitialDataWithID(p.ID, new PlayerMovedInitialData(p.State!.Clone())));
-            }
-            return (IReadOnlyCollection<PlayerMovedInitialDataWithID>)list;
-        });
+            var p = con.Player;
+            // players that in debug map can cause null state
+            if (con == except || p.State is null)
+                continue;
+            list.Add(new PlayerMovedInitialDataWithID(p.ID, new PlayerMovedInitialData(p.State!.Clone())));
+        }
+        return list;
     }
 
     public void Dispose()
     {
-        workQueue.Writer.Complete();
-        consumer.Wait();
+        StateLock.Dispose();
     }
 }

--- a/source/MiaoNet.Server/Data/ServerPlayer.cs
+++ b/source/MiaoNet.Server/Data/ServerPlayer.cs
@@ -24,8 +24,6 @@ public sealed class ServerPlayer
 
     public ScopeTuple Scope { get; set; }
 
-    
-
     public ServerPlayer(ServerChannel channel, int id, PlayerInfo info)
     {
         fireworksTokenBucket = new(500, 500 * 3);

--- a/source/MiaoNet.Server/Data/ServerPlayer.cs
+++ b/source/MiaoNet.Server/Data/ServerPlayer.cs
@@ -8,7 +8,7 @@ public sealed class ServerPlayer
 {
     private readonly TokenBucket fireworksTokenBucket;
 
-    public ServerChannel Channel { get; set; }
+    public ServerChannel Channel => Scope.Channel!;
 
     public int ID { get; }
 
@@ -22,11 +22,15 @@ public sealed class ServerPlayer
 
     public PlayerGlobalFlags GlobalFlags { get; set; }
 
+    public ScopeTuple Scope { get; set; }
+
+    
+
     public ServerPlayer(ServerChannel channel, int id, PlayerInfo info)
     {
         fireworksTokenBucket = new(500, 500 * 3);
 
-        Channel = channel;
+        Scope = new ScopeTuple(channel, null);
         ID = id;
         Info = info;
         Location = PlayerLocation.Empty;

--- a/source/MiaoNet.Server/Data/ServerRoom.cs
+++ b/source/MiaoNet.Server/Data/ServerRoom.cs
@@ -1,0 +1,33 @@
+using System.Collections.Immutable;
+
+namespace MiaoNet.Server;
+
+// TODO: wire up handler
+public sealed class ServerRoom : IPlayerScope
+{
+    private ImmutableHashSet<MiaoClientConnection> players;
+
+    public string RoomId { get; }
+
+    public ImmutableHashSet<MiaoClientConnection> Players => players;
+
+    IEnumerable<MiaoClientConnection> IPlayerScope.Players => players;
+
+    public IEnumerable<MiaoClientConnection> AllPlayers => players;
+
+    public ServerRoom(string roomId)
+    {
+        RoomId = roomId;
+        players = ImmutableHashSet<MiaoClientConnection>.Empty;
+    }
+
+    public void OnAddPlayer(MiaoClientConnection connection)
+    {
+        ImmutableInterlocked.Update(ref players, (d, c) => d.Add(c), connection);
+    }
+
+    public void OnRemovePlayer(MiaoClientConnection connection)
+    {
+        ImmutableInterlocked.Update(ref players, (d, c) => d.Remove(c), connection);
+    }
+}

--- a/source/MiaoNet.Server/Data/ServerState.cs
+++ b/source/MiaoNet.Server/Data/ServerState.cs
@@ -70,7 +70,7 @@ public sealed class ServerState : IPlayerScope
         var from = connection.Player.Channel;
         Debug.Assert(channels.ContainsValue(from));
         Debug.Assert(channels.ContainsValue(to));
-        
+
         from.OnRemovePlayer(connection);
         connection.Player.Scope.Channel = to;
         to.OnAddPlayer(connection);

--- a/source/MiaoNet.Server/Data/ServerState.cs
+++ b/source/MiaoNet.Server/Data/ServerState.cs
@@ -1,7 +1,5 @@
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using MiaoNet.Shared;
 
 namespace MiaoNet.Server;
@@ -66,15 +64,26 @@ public sealed class ServerState : IPlayerScope
         RemoveChannelIfEmpty(connection.Player.Channel);
     }
 
-    public void PlayerChannelMove(MiaoClientConnection connection, ServerChannel from, ServerChannel to)
+    public MoveResult PlayerChannelMove(MiaoClientConnection connection, ServerChannel to)
     {
+        var fromScope = connection.Player.Scope;
+        var from = connection.Player.Channel;
         Debug.Assert(channels.ContainsValue(from));
         Debug.Assert(channels.ContainsValue(to));
-
+        
         from.OnRemovePlayer(connection);
-        connection.Player.Channel = to;
+        connection.Player.Scope.Channel = to;
         to.OnAddPlayer(connection);
         RemoveChannelIfEmpty(from);
+        
+        return new MoveResult(fromScope, connection.Player.Scope);
+    }
+
+    public MoveResult PlayerMapMove(MiaoClientConnection connection, PlayerMapLocation to)
+    {
+        var fromScope = connection.Player.Scope;
+        connection.Player.Channel.OnPlayerMapMove(connection, to);
+        return new MoveResult(fromScope, connection.Player.Scope);
     }
 
     private void RemoveChannelIfEmpty(ServerChannel channel)

--- a/source/MiaoNet.Server/Data/ServerState.cs
+++ b/source/MiaoNet.Server/Data/ServerState.cs
@@ -80,11 +80,7 @@ public sealed class ServerState : IPlayerScope
     }
 
     public MoveResult PlayerMapMove(MiaoClientConnection connection, PlayerMapLocation to)
-    {
-        var fromScope = connection.Player.Scope;
-        connection.Player.Channel.OnPlayerMapMove(connection, to);
-        return new MoveResult(fromScope, connection.Player.Scope);
-    }
+        => connection.Player.Channel.OnPlayerMapMove(connection, to);
 
     private void RemoveChannelIfEmpty(ServerChannel channel)
     {

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -111,6 +111,7 @@ public sealed partial class MiaoServerService
                         mapTo.StateLock.ExitWriteLock();
                     }
                 }
+
                 var moveResult = ServerState.PlayerMapMove(connection, newLocation.Map);
                 player.Location = newLocation;
                 player.State = null;
@@ -179,7 +180,6 @@ public sealed partial class MiaoServerService
                 moveResult.To.Map?.StateLock.ExitWriteLock();
             }
         }
-        
 
         await generalTask;
         await withStateTask;

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -84,7 +84,7 @@ public sealed partial class MiaoServerService
         if (!newLocation.IsInMap)
         {
             Task othersTask;
-            ValueTask debugSnapshotTask = default;
+            Task<IReadOnlyCollection<PlayerMovedInitialDataWithID>>? mapPlayersTask = null;
             using (stateLock.AcquireWriteLock())
             {
                 othersTask = BroadcastToScopeExceptAsync(
@@ -93,22 +93,24 @@ public sealed partial class MiaoServerService
                     connection.ID
                 );
 
+                var moveResult = ServerState.PlayerMapMove(connection, newLocation.Map);
+                player.Location = newLocation;
+                player.State = null;
+
                 // if the player is going to debug map
                 // sending states here is necessary currently
                 if (newLocation.IsInDebugMap && player.Channel.Maps.TryGetValue(newLocation.Map, out var mapTo))
                 {
-                    var mapPlayers = mapTo.GetPlayerMovedInitialDatas(connection);
-                    debugSnapshotTask = connection.QueuePacketAsync(
-                        new PacketPlayerLocationChangedResponse(mapPlayers));
+                    mapPlayersTask = mapTo.GetPlayerMovedInitialDatasAsync(connection);
                 }
-
-                var moveResult = ServerState.PlayerMapMove(connection, newLocation.Map);
-                player.Location = newLocation;
-                player.State = null;
             }
 
             await othersTask;
-            await debugSnapshotTask;
+            if (mapPlayersTask != null)
+            {
+                var mapPlayers = await mapPlayersTask;
+                await connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(mapPlayers));
+            }
             return;
         }
 
@@ -139,15 +141,11 @@ public sealed partial class MiaoServerService
 
         Debug.Assert(newLocation.IsInMap);
         Task generalTask, withStateTask;
-        ValueTask responseTask = default;
+        Task<IReadOnlyCollection<PlayerMovedInitialDataWithID>>? mapPlayersTask2 = null;
 
         using (stateLock.AcquireWriteLock())
         {
-            var c = player.Channel;
             var moveResult = serverState.PlayerMapMove(connection, newLocation.Map);
-
-            var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection) ?? [];
-            var responsePacket = new PacketPlayerLocationChangedResponse(mapPlayers);
 
             var generalPacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, null);
             var withStatePacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, packet.InitialState);
@@ -159,15 +157,28 @@ public sealed partial class MiaoServerService
             withStateTask = moveResult.To.Map is not null
                 ? BroadcastToScopeExceptAsync(withStatePacket, moveResult.To.Map, connection.ID)
                 : Task.CompletedTask;
-            responseTask = connection.QueuePacketAsync(responsePacket);
 
             player.Location = newLocation;
             player.State = packet.InitialState;
+
+            if (moveResult.To.Map is not null)
+            {
+                mapPlayersTask2 = moveResult.To.Map.GetPlayerMovedInitialDatasAsync(connection);
+            }
         }
 
         await generalTask;
         await withStateTask;
-        await responseTask;
+
+        if (mapPlayersTask2 != null)
+        {
+            var mapPlayers = await mapPlayersTask2;
+            await connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(mapPlayers));
+        }
+        else
+        {
+            await connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(Array.Empty<PlayerMovedInitialDataWithID>()));
+        }
     }
 
     private async Task HandlePacketAsync(MiaoClientConnection connection, PacketPlayerChannelMove packet)
@@ -179,16 +190,17 @@ public sealed partial class MiaoServerService
         }
         var player = connection.Player;
 
-        ValueTask responseTask;
+        Task<IReadOnlyCollection<PlayerMovedInitialDataWithID>>? mapPlayersTask3 = null;
         Task sameMapTask;
         Task sameChannelTask;
         Task crossChannelTask;
+        List<PlayerPresenceDataWithID> channelPlayers;
 
         using (stateLock.AcquireWriteLock())
         {
             var moveResult = serverState.PlayerChannelMove(connection, channel);
 
-            var channelPlayers = new List<PlayerPresenceDataWithID>(channel.Players.Count);
+            channelPlayers = new List<PlayerPresenceDataWithID>(channel.Players.Count);
             foreach (var c in channel.Players)
             {
                 if (c.ID == connection.ID)
@@ -197,10 +209,11 @@ public sealed partial class MiaoServerService
                     c.ID, new PlayerPresenceData(c.Player.Location, c.Player.GlobalFlags)
                 ));
             }
-            var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection);
 
-            var responsePacket = new PacketPlayerChannelMovedResponse(channel.ID, mapPlayers, channelPlayers);
-            responseTask = connection.QueuePacketAsync(responsePacket);
+            if (moveResult.To.Map is not null)
+            {
+                mapPlayersTask3 = moveResult.To.Map.GetPlayerMovedInitialDatasAsync(connection);
+            }
 
             var sameMapNotification = new PacketPlayerChannelMovedNotification(
                 connection.ID, channel.ID,
@@ -227,7 +240,16 @@ public sealed partial class MiaoServerService
             );
         }
 
-        await responseTask;
+        if (mapPlayersTask3 != null)
+        {
+            var mapPlayers = await mapPlayersTask3;
+            await connection.QueuePacketAsync(new PacketPlayerChannelMovedResponse(channel.ID, mapPlayers, channelPlayers));
+        }
+        else
+        {
+            await connection.QueuePacketAsync(new PacketPlayerChannelMovedResponse(channel.ID, null, channelPlayers));
+        }
+
         await sameMapTask;
         await sameChannelTask;
         await crossChannelTask;

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -56,19 +56,17 @@ public sealed partial class MiaoServerService
             return;
         }
 
-        // TODO we can actually using one Task for one Map
-        // to handle these updates lock-free
         ServerMap u = player.Channel.Maps[player.Location.Map];
-        using (u.StateLock.AcquireReadLock())
+        await u.PostAsync(() =>
         {
-            var state = player.State;
-            state.ApplyDelta(delta);
-        }
-        await BroadcastToScopeExceptAsync(
-            new PacketContextualPlayerNotification<PacketPlayerFrame>(connection.ID, packet),
-            u,
-            connection.ID
-        );
+            player.State.ApplyDelta(delta);
+            BroadcastToScopeExceptAsync(
+                new PacketContextualPlayerNotification<PacketPlayerFrame>(connection.ID, packet),
+                u,
+                connection.ID
+            );
+            return Task.CompletedTask;
+        });
     }
 
     private async Task HandlePacketAsync(MiaoClientConnection connection, PacketPlayerLocationChanged packet)
@@ -99,20 +97,12 @@ public sealed partial class MiaoServerService
                 // sending states here is necessary currently
                 if (newLocation.IsInDebugMap && player.Channel.Maps.TryGetValue(newLocation.Map, out var mapTo))
                 {
-                    mapTo.StateLock.EnterWriteLock();
-                    try
-                    {
-                        var mapPlayers = mapTo.GetPlayerMovedInitialDatas(connection);
-                        debugSnapshotTask = connection.QueuePacketAsync(
-                            new PacketPlayerLocationChangedResponse(mapPlayers));
-                    }
-                    finally
-                    {
-                        mapTo.StateLock.ExitWriteLock();
-                    }
+                    var mapPlayers = mapTo.GetPlayerMovedInitialDatas(connection);
+                    debugSnapshotTask = connection.QueuePacketAsync(
+                        new PacketPlayerLocationChangedResponse(mapPlayers));
                 }
 
-                player.Channel.OnPlayerMapMove(connection, oldLocation.Map, newLocation.Map);
+                var moveResult = ServerState.PlayerMapMove(connection, newLocation.Map);
                 player.Location = newLocation;
                 player.State = null;
             }
@@ -154,34 +144,25 @@ public sealed partial class MiaoServerService
         using (stateLock.AcquireWriteLock())
         {
             var c = player.Channel;
-            c.Maps.TryGetValue(newLocation.Map, out var mapTo);
+            var moveResult = serverState.PlayerMapMove(connection, newLocation.Map);
 
-            mapTo?.StateLock.EnterWriteLock();
-            try
-            {
-                var generalPacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, null);
-                var withStatePacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, packet.InitialState);
+            var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection) ?? [];
+            var responsePacket = new PacketPlayerLocationChangedResponse(mapPlayers);
 
-                var mapPlayers = mapTo?.GetPlayerMovedInitialDatas(connection) ?? [];
-                var responsePacket = new PacketPlayerLocationChangedResponse(mapPlayers);
+            var generalPacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, null);
+            var withStatePacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, packet.InitialState);
 
-                generalTask = mapTo is not null
-                    ? BroadcastToScopeExceptAsync(generalPacket, player.Channel, connection.ID, c => !mapTo.Players.Contains(c))
-                    : BroadcastToScopeExceptAsync(generalPacket, player.Channel, connection.ID);
+            generalTask = moveResult.To.Map is not null
+                ? BroadcastToScopeExceptAsync(generalPacket, moveResult.To.Map, connection.ID)
+                : BroadcastToScopeExceptAsync(generalPacket, player.Channel, connection.ID);
 
-                withStateTask = mapTo is not null
-                    ? BroadcastToScopeExceptAsync(withStatePacket, mapTo, connection.ID)
-                    : Task.CompletedTask;
-                responseTask = connection.QueuePacketAsync(responsePacket);
+            withStateTask = moveResult.To.Map is not null
+                ? BroadcastToScopeExceptAsync(withStatePacket, moveResult.To.Map, connection.ID)
+                : Task.CompletedTask;
+            responseTask = connection.QueuePacketAsync(responsePacket);
 
-                c.OnPlayerMapMove(connection, oldLocation.Map, newLocation.Map);
-                player.Location = newLocation;
-                player.State = packet.InitialState;
-            }
-            finally
-            {
-                mapTo?.StateLock.ExitWriteLock();
-            }
+            player.Location = newLocation;
+            player.State = packet.InitialState;
         }
 
         await generalTask;
@@ -205,62 +186,45 @@ public sealed partial class MiaoServerService
 
         using (stateLock.AcquireWriteLock())
         {
-            channel.Maps.TryGetValue(player.Location.Map, out ServerMap? mapTo);
-            mapTo?.StateLock.EnterWriteLock();
-            try
+            var moveResult = serverState.PlayerChannelMove(connection, channel);
+
+            var channelPlayers = new List<PlayerPresenceDataWithID>(channel.Players.Count);
+            foreach (var c in channel.Players)
             {
-                var channelPlayers = new List<PlayerPresenceDataWithID>(channel.Players.Count);
-                foreach (var c in channel.Players)
-                {
-                    if (c.ID == connection.ID)
-                        continue;
-                    channelPlayers.Add(new PlayerPresenceDataWithID(
-                        c.ID, new PlayerPresenceData(c.Player.Location, c.Player.GlobalFlags)
-                    ));
-                }
-                var mapPlayers = mapTo?.GetPlayerMovedInitialDatas(connection);
-
-                var responsePacket = new PacketPlayerChannelMovedResponse(channel.ID, mapPlayers, channelPlayers);
-                responseTask = connection.QueuePacketAsync(responsePacket);
-
-                // same-map players in the target channel get state + presence
-                var sameMapNotification = new PacketPlayerChannelMovedNotification(
-                    connection.ID,
-                    channel.ID,
-                    player.State is null ? null : new PlayerMovedInitialData(player.State),
-                    new PlayerPresenceData(player.Location, player.GlobalFlags)
-                );
-                sameMapTask = mapTo is not null
-                    ? BroadcastToScopeExceptAsync(sameMapNotification, mapTo, connection.ID)
-                    : Task.CompletedTask;
-
-                var sameChannelNotification = new PacketPlayerChannelMovedNotification(
-                    connection.ID,
-                    channel.ID,
-                    null,
-                    new PlayerPresenceData(player.Location, player.GlobalFlags)
-                );
-                sameChannelTask = BroadcastToScopeExceptAsync(
-                    sameChannelNotification,
-                    channel,
-                    connection.ID,
-                    c => mapTo is null || !mapTo.Players.Contains(c)
-                );
-
-                var crossChannelNotification = new PacketPlayerChannelMovedNotification(connection.ID, channel.ID);
-                crossChannelTask = BroadcastToScopeExceptAsync(
-                    crossChannelNotification,
-                    serverState,
-                    connection.ID,
-                    c => c.Player.Channel != channel
-                );
+                if (c.ID == connection.ID)
+                    continue;
+                channelPlayers.Add(new PlayerPresenceDataWithID(
+                    c.ID, new PlayerPresenceData(c.Player.Location, c.Player.GlobalFlags)
+                ));
             }
-            finally
-            {
-                mapTo?.StateLock.ExitWriteLock();
-            }
+            var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection);
 
-            serverState.PlayerChannelMove(connection, player.Channel, channel);
+            var responsePacket = new PacketPlayerChannelMovedResponse(channel.ID, mapPlayers, channelPlayers);
+            responseTask = connection.QueuePacketAsync(responsePacket);
+
+            var sameMapNotification = new PacketPlayerChannelMovedNotification(
+                connection.ID, channel.ID,
+                player.State is null ? null : new PlayerMovedInitialData(player.State),
+                new PlayerPresenceData(player.Location, player.GlobalFlags)
+            );
+            sameMapTask = moveResult.To.Map is not null
+                ? BroadcastToScopeExceptAsync(sameMapNotification, moveResult.To.Map, connection.ID)
+                : Task.CompletedTask;
+
+            var sameChannelNotification = new PacketPlayerChannelMovedNotification(
+                connection.ID, channel.ID, null,
+                new PlayerPresenceData(player.Location, player.GlobalFlags)
+            );
+            sameChannelTask = BroadcastToScopeExceptAsync(
+                sameChannelNotification, channel, connection.ID,
+                c => moveResult.To.Map is null || !moveResult.To.Map.Players.Contains(c)
+            );
+
+            var crossChannelNotification = new PacketPlayerChannelMovedNotification(connection.ID, channel.ID);
+            crossChannelTask = BroadcastToScopeExceptAsync(
+                crossChannelNotification, serverState, connection.ID,
+                c => c.Player.Channel != channel
+            );
         }
 
         await responseTask;
@@ -279,7 +243,7 @@ public sealed partial class MiaoServerService
         {
             var channel = serverState.CreateNewChannel(packet.ChannelInfo);
             serverState.AddChannel(channel);
-            serverState.PlayerChannelMove(connection, connection.Player.Channel, channel);
+            serverState.PlayerChannelMove(connection, channel);
 
             createdTask = BroadcastToScopeAsync(new PacketChannelCreated(channel.ID, channel.Info), serverState);
             movedTask = BroadcastToScopeExceptAsync(
@@ -321,11 +285,9 @@ public sealed partial class MiaoServerService
             await BroadcastToScopeAsync(toSend, connection.Player.Channel);
             break;
         case ChatMessageType.MapChat:
-            await BroadcastToScopeAsync(
-                toSend,
-                connection.Player.Channel,
-                c => c.Player.Location.Map == connection.Player.Location.Map
-            );
+            var mapScope = connection.Player.Scope.Map;
+            if (mapScope is not null)
+                await BroadcastToScopeAsync(toSend, mapScope);
             break;
         default:
             goto case ChatMessageType.Chat;

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -162,7 +162,7 @@ public sealed partial class MiaoServerService
                 var withStatePacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, packet.InitialState);
                 
                 var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection) ?? [];
-                responseTask = connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(mapPlayers));
+                var responsePacket = new PacketPlayerLocationChangedResponse(mapPlayers);
 
                 generalTask = moveResult.To.Map is not null
                     ? BroadcastToScopeExceptAsync(generalPacket, moveResult.To.Map, connection.ID)
@@ -171,6 +171,7 @@ public sealed partial class MiaoServerService
                 withStateTask = moveResult.To.Map is not null
                     ? BroadcastToScopeExceptAsync(withStatePacket, moveResult.To.Map, connection.ID)
                     : Task.CompletedTask;
+                responseTask = connection.QueuePacketAsync(responsePacket);
 
                 player.Location = newLocation;
                 player.State = packet.InitialState;
@@ -221,7 +222,8 @@ public sealed partial class MiaoServerService
                 responseTask = connection.QueuePacketAsync(responsePacket);
 
                 var sameMapNotification = new PacketPlayerChannelMovedNotification(
-                    connection.ID, channel.ID,
+                    connection.ID,
+                    channel.ID,
                     player.State is null ? null : new PlayerMovedInitialData(player.State),
                     new PlayerPresenceData(player.Location, player.GlobalFlags)
                 );
@@ -230,17 +232,23 @@ public sealed partial class MiaoServerService
                     : Task.CompletedTask;
 
                 var sameChannelNotification = new PacketPlayerChannelMovedNotification(
-                    connection.ID, channel.ID, null,
+                    connection.ID,
+                    channel.ID,
+                    null,
                     new PlayerPresenceData(player.Location, player.GlobalFlags)
                 );
                 sameChannelTask = BroadcastToScopeExceptAsync(
-                    sameChannelNotification, channel, connection.ID,
+                    sameChannelNotification,
+                    channel,
+                    connection.ID,
                     c => moveResult.To.Map is null || !moveResult.To.Map.Players.Contains(c)
                 );
 
                 var crossChannelNotification = new PacketPlayerChannelMovedNotification(connection.ID, channel.ID);
                 crossChannelTask = BroadcastToScopeExceptAsync(
-                    crossChannelNotification, serverState, connection.ID,
+                    crossChannelNotification,
+                    serverState,
+                    connection.ID,
                     c => c.Player.Channel != channel
                 );
             }

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -57,16 +57,15 @@ public sealed partial class MiaoServerService
         }
 
         ServerMap u = player.Channel.Maps[player.Location.Map];
-        await u.PostAsync(() =>
+        using (u.StateLock.AcquireReadLock())
         {
             player.State.ApplyDelta(delta);
-            BroadcastToScopeExceptAsync(
-                new PacketContextualPlayerNotification<PacketPlayerFrame>(connection.ID, packet),
-                u,
-                connection.ID
-            );
-            return Task.CompletedTask;
-        });
+        }
+        await BroadcastToScopeExceptAsync(
+            new PacketContextualPlayerNotification<PacketPlayerFrame>(connection.ID, packet),
+            u,
+            connection.ID
+        );
     }
 
     private async Task HandlePacketAsync(MiaoClientConnection connection, PacketPlayerLocationChanged packet)
@@ -84,7 +83,7 @@ public sealed partial class MiaoServerService
         if (!newLocation.IsInMap)
         {
             Task othersTask;
-            Task<IReadOnlyCollection<PlayerMovedInitialDataWithID>>? mapPlayersTask = null;
+            ValueTask debugSnapshotTask = default;
             using (stateLock.AcquireWriteLock())
             {
                 othersTask = BroadcastToScopeExceptAsync(
@@ -101,16 +100,22 @@ public sealed partial class MiaoServerService
                 // sending states here is necessary currently
                 if (newLocation.IsInDebugMap && player.Channel.Maps.TryGetValue(newLocation.Map, out var mapTo))
                 {
-                    mapPlayersTask = mapTo.GetPlayerMovedInitialDatasAsync(connection);
+                    mapTo.StateLock.EnterWriteLock();
+                    try
+                    {
+                        var mapPlayers = mapTo.GetPlayerMovedInitialDatas(connection);
+                        debugSnapshotTask = connection.QueuePacketAsync(
+                            new PacketPlayerLocationChangedResponse(mapPlayers));
+                    }
+                    finally
+                    {
+                        mapTo.StateLock.ExitWriteLock();
+                    }
                 }
             }
 
             await othersTask;
-            if (mapPlayersTask != null)
-            {
-                var mapPlayers = await mapPlayersTask;
-                await connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(mapPlayers));
-            }
+            await debugSnapshotTask;
             return;
         }
 
@@ -141,44 +146,41 @@ public sealed partial class MiaoServerService
 
         Debug.Assert(newLocation.IsInMap);
         Task generalTask, withStateTask;
-        Task<IReadOnlyCollection<PlayerMovedInitialDataWithID>>? mapPlayersTask2 = null;
+        ValueTask responseTask = default;
 
         using (stateLock.AcquireWriteLock())
         {
             var moveResult = serverState.PlayerMapMove(connection, newLocation.Map);
 
-            var generalPacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, null);
-            var withStatePacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, packet.InitialState);
-
-            generalTask = moveResult.To.Map is not null
-                ? BroadcastToScopeExceptAsync(generalPacket, moveResult.To.Map, connection.ID)
-                : BroadcastToScopeExceptAsync(generalPacket, player.Channel, connection.ID);
-
-            withStateTask = moveResult.To.Map is not null
-                ? BroadcastToScopeExceptAsync(withStatePacket, moveResult.To.Map, connection.ID)
-                : Task.CompletedTask;
-
-            player.Location = newLocation;
-            player.State = packet.InitialState;
-
-            if (moveResult.To.Map is not null)
+            moveResult.To.Map?.StateLock.EnterWriteLock();
+            try
             {
-                mapPlayersTask2 = moveResult.To.Map.GetPlayerMovedInitialDatasAsync(connection);
+                var generalPacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, null);
+                var withStatePacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, packet.InitialState);
+
+                generalTask = moveResult.To.Map is not null
+                    ? BroadcastToScopeExceptAsync(generalPacket, moveResult.To.Map, connection.ID)
+                    : BroadcastToScopeExceptAsync(generalPacket, player.Channel, connection.ID);
+
+                withStateTask = moveResult.To.Map is not null
+                    ? BroadcastToScopeExceptAsync(withStatePacket, moveResult.To.Map, connection.ID)
+                    : Task.CompletedTask;
+
+                player.Location = newLocation;
+                player.State = packet.InitialState;
+
+                var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection) ?? Array.Empty<PlayerMovedInitialDataWithID>();
+                responseTask = connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(mapPlayers));
+            }
+            finally
+            {
+                moveResult.To.Map?.StateLock.ExitWriteLock();
             }
         }
 
         await generalTask;
         await withStateTask;
-
-        if (mapPlayersTask2 != null)
-        {
-            var mapPlayers = await mapPlayersTask2;
-            await connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(mapPlayers));
-        }
-        else
-        {
-            await connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(Array.Empty<PlayerMovedInitialDataWithID>()));
-        }
+        await responseTask;
     }
 
     private async Task HandlePacketAsync(MiaoClientConnection connection, PacketPlayerChannelMove packet)
@@ -190,17 +192,16 @@ public sealed partial class MiaoServerService
         }
         var player = connection.Player;
 
-        Task<IReadOnlyCollection<PlayerMovedInitialDataWithID>>? mapPlayersTask3 = null;
+        ValueTask responseTask;
         Task sameMapTask;
         Task sameChannelTask;
         Task crossChannelTask;
-        List<PlayerPresenceDataWithID> channelPlayers;
 
         using (stateLock.AcquireWriteLock())
         {
             var moveResult = serverState.PlayerChannelMove(connection, channel);
 
-            channelPlayers = new List<PlayerPresenceDataWithID>(channel.Players.Count);
+            var channelPlayers = new List<PlayerPresenceDataWithID>(channel.Players.Count);
             foreach (var c in channel.Players)
             {
                 if (c.ID == connection.ID)
@@ -210,9 +211,16 @@ public sealed partial class MiaoServerService
                 ));
             }
 
-            if (moveResult.To.Map is not null)
+            moveResult.To.Map?.StateLock.EnterWriteLock();
+            try
             {
-                mapPlayersTask3 = moveResult.To.Map.GetPlayerMovedInitialDatasAsync(connection);
+                var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection);
+                var responsePacket = new PacketPlayerChannelMovedResponse(channel.ID, mapPlayers, channelPlayers);
+                responseTask = connection.QueuePacketAsync(responsePacket);
+            }
+            finally
+            {
+                moveResult.To.Map?.StateLock.ExitWriteLock();
             }
 
             var sameMapNotification = new PacketPlayerChannelMovedNotification(
@@ -240,15 +248,10 @@ public sealed partial class MiaoServerService
             );
         }
 
-        if (mapPlayersTask3 != null)
-        {
-            var mapPlayers = await mapPlayersTask3;
-            await connection.QueuePacketAsync(new PacketPlayerChannelMovedResponse(channel.ID, mapPlayers, channelPlayers));
-        }
-        else
-        {
-            await connection.QueuePacketAsync(new PacketPlayerChannelMovedResponse(channel.ID, null, channelPlayers));
-        }
+        await responseTask;
+        await sameMapTask;
+        await sameChannelTask;
+        await crossChannelTask;
 
         await sameMapTask;
         await sameChannelTask;

--- a/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
+++ b/source/MiaoNet.Server/Server/MiaoServerService.PacketHandling.cs
@@ -56,10 +56,13 @@ public sealed partial class MiaoServerService
             return;
         }
 
+        // TODO we can actually using one Task for one Map
+        // to handle these updates lock-free
         ServerMap u = player.Channel.Maps[player.Location.Map];
         using (u.StateLock.AcquireReadLock())
         {
-            player.State.ApplyDelta(delta);
+            var state = player.State;
+            state.ApplyDelta(delta);
         }
         await BroadcastToScopeExceptAsync(
             new PacketContextualPlayerNotification<PacketPlayerFrame>(connection.ID, packet),
@@ -92,10 +95,6 @@ public sealed partial class MiaoServerService
                     connection.ID
                 );
 
-                var moveResult = ServerState.PlayerMapMove(connection, newLocation.Map);
-                player.Location = newLocation;
-                player.State = null;
-
                 // if the player is going to debug map
                 // sending states here is necessary currently
                 if (newLocation.IsInDebugMap && player.Channel.Maps.TryGetValue(newLocation.Map, out var mapTo))
@@ -112,6 +111,9 @@ public sealed partial class MiaoServerService
                         mapTo.StateLock.ExitWriteLock();
                     }
                 }
+                var moveResult = ServerState.PlayerMapMove(connection, newLocation.Map);
+                player.Location = newLocation;
+                player.State = null;
             }
 
             await othersTask;
@@ -157,6 +159,9 @@ public sealed partial class MiaoServerService
             {
                 var generalPacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, null);
                 var withStatePacket = new PacketPlayerLocationChangedNotification(player.ID, newLocation, packet.InitialState);
+                
+                var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection) ?? [];
+                responseTask = connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(mapPlayers));
 
                 generalTask = moveResult.To.Map is not null
                     ? BroadcastToScopeExceptAsync(generalPacket, moveResult.To.Map, connection.ID)
@@ -168,15 +173,13 @@ public sealed partial class MiaoServerService
 
                 player.Location = newLocation;
                 player.State = packet.InitialState;
-
-                var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection) ?? Array.Empty<PlayerMovedInitialDataWithID>();
-                responseTask = connection.QueuePacketAsync(new PacketPlayerLocationChangedResponse(mapPlayers));
             }
             finally
             {
                 moveResult.To.Map?.StateLock.ExitWriteLock();
             }
         }
+        
 
         await generalTask;
         await withStateTask;
@@ -200,59 +203,54 @@ public sealed partial class MiaoServerService
         using (stateLock.AcquireWriteLock())
         {
             var moveResult = serverState.PlayerChannelMove(connection, channel);
-
-            var channelPlayers = new List<PlayerPresenceDataWithID>(channel.Players.Count);
-            foreach (var c in channel.Players)
-            {
-                if (c.ID == connection.ID)
-                    continue;
-                channelPlayers.Add(new PlayerPresenceDataWithID(
-                    c.ID, new PlayerPresenceData(c.Player.Location, c.Player.GlobalFlags)
-                ));
-            }
-
             moveResult.To.Map?.StateLock.EnterWriteLock();
             try
             {
+                var channelPlayers = new List<PlayerPresenceDataWithID>(channel.Players.Count);
+                foreach (var c in channel.Players)
+                {
+                    if (c.ID == connection.ID)
+                        continue;
+                    channelPlayers.Add(new PlayerPresenceDataWithID(
+                        c.ID, new PlayerPresenceData(c.Player.Location, c.Player.GlobalFlags)
+                    ));
+                }
+
                 var mapPlayers = moveResult.To.Map?.GetPlayerMovedInitialDatas(connection);
                 var responsePacket = new PacketPlayerChannelMovedResponse(channel.ID, mapPlayers, channelPlayers);
                 responseTask = connection.QueuePacketAsync(responsePacket);
+
+                var sameMapNotification = new PacketPlayerChannelMovedNotification(
+                    connection.ID, channel.ID,
+                    player.State is null ? null : new PlayerMovedInitialData(player.State),
+                    new PlayerPresenceData(player.Location, player.GlobalFlags)
+                );
+                sameMapTask = moveResult.To.Map is not null
+                    ? BroadcastToScopeExceptAsync(sameMapNotification, moveResult.To.Map, connection.ID)
+                    : Task.CompletedTask;
+
+                var sameChannelNotification = new PacketPlayerChannelMovedNotification(
+                    connection.ID, channel.ID, null,
+                    new PlayerPresenceData(player.Location, player.GlobalFlags)
+                );
+                sameChannelTask = BroadcastToScopeExceptAsync(
+                    sameChannelNotification, channel, connection.ID,
+                    c => moveResult.To.Map is null || !moveResult.To.Map.Players.Contains(c)
+                );
+
+                var crossChannelNotification = new PacketPlayerChannelMovedNotification(connection.ID, channel.ID);
+                crossChannelTask = BroadcastToScopeExceptAsync(
+                    crossChannelNotification, serverState, connection.ID,
+                    c => c.Player.Channel != channel
+                );
             }
             finally
             {
                 moveResult.To.Map?.StateLock.ExitWriteLock();
             }
-
-            var sameMapNotification = new PacketPlayerChannelMovedNotification(
-                connection.ID, channel.ID,
-                player.State is null ? null : new PlayerMovedInitialData(player.State),
-                new PlayerPresenceData(player.Location, player.GlobalFlags)
-            );
-            sameMapTask = moveResult.To.Map is not null
-                ? BroadcastToScopeExceptAsync(sameMapNotification, moveResult.To.Map, connection.ID)
-                : Task.CompletedTask;
-
-            var sameChannelNotification = new PacketPlayerChannelMovedNotification(
-                connection.ID, channel.ID, null,
-                new PlayerPresenceData(player.Location, player.GlobalFlags)
-            );
-            sameChannelTask = BroadcastToScopeExceptAsync(
-                sameChannelNotification, channel, connection.ID,
-                c => moveResult.To.Map is null || !moveResult.To.Map.Players.Contains(c)
-            );
-
-            var crossChannelNotification = new PacketPlayerChannelMovedNotification(connection.ID, channel.ID);
-            crossChannelTask = BroadcastToScopeExceptAsync(
-                crossChannelNotification, serverState, connection.ID,
-                c => c.Player.Channel != channel
-            );
         }
 
         await responseTask;
-        await sameMapTask;
-        await sameChannelTask;
-        await crossChannelTask;
-
         await sameMapTask;
         await sameChannelTask;
         await crossChannelTask;


### PR DESCRIPTION
虽然现在没有单独需要对移动前位置广播的消息，但先留一个接口在这（？
另外预留Room级scope供将来非全量状态传输使用。