### PR TITLE
feature(Client): 优化Tab操作体验，增加新消息显示模式设置

### DIFF
--- a/source/ChatInputBox/ChatInputBox/ChatMessageBox.cs
+++ b/source/ChatInputBox/ChatInputBox/ChatMessageBox.cs
@@ -23,7 +23,9 @@ public class ChatMessageBox
         => chatMessageManager.AddChatMessage(new(dateTime, message), tabName);
         
 
-    public void CycleTab() => chatMessageManager.CycleTab();
+    public void CycleTabForward() => chatMessageManager.CycleTabForward();
+    
+    public void CycleTabBackward() => chatMessageManager.CycleTabBackward();
 
     public void AddTab(string name) => chatMessageManager.AddTab(name);
 

--- a/source/ChatInputBox/ChatInputBox/ChatMessageListView.cs
+++ b/source/ChatInputBox/ChatInputBox/ChatMessageListView.cs
@@ -111,15 +111,8 @@ public sealed class ChatMessageListView
             var state = getOrInitViewState(item);
             if (state.ShowTimer > 0f)
             {
-                if (NewMessagesShowing == NewMessageShowingMode.HideAll)
-                {
-                    state.ShowTimer = 0f;
-                    state.FadeOut = 0f;
-                }
-                else
-                {
-                    state.ShowTimer -= Engine.RawDeltaTime;
-                }
+                // NoNewMessage now renders an empty list so no need to manually fade message out anymore.
+                state.ShowTimer -= Engine.RawDeltaTime;
             }
             else
             {

--- a/source/ChatInputBox/ChatInputBox/ChatMessageListView.cs
+++ b/source/ChatInputBox/ChatInputBox/ChatMessageListView.cs
@@ -18,7 +18,11 @@ public sealed class ChatMessageListView
     private float targetScroll;
     private float scroll;
 
-    private List<ChatItem> chatLog => chatMessageManager.ActiveChatLog;
+    private List<ChatItem> chatLog => active || NewMessagesShowing == NewMessageShowingMode.WithTab
+        ? chatMessageManager.ActiveChatLog
+        : NewMessagesShowing == NewMessageShowingMode.ShowAll
+            ? fullChatLog
+            : [];
     private List<ChatItem> fullChatLog => chatMessageManager.ChatLog;
 
     
@@ -32,7 +36,7 @@ public sealed class ChatMessageListView
 
     public float ShowDuration { get; set; } = 8f;
 
-    public bool NoNewMessagesShowing { get; set; }
+    public NewMessageShowingMode NewMessagesShowing { get; set; } = NewMessageShowingMode.ShowAll;
 
     public string? ActiveTabName => chatMessageManager.ActiveTabName;
 
@@ -107,7 +111,7 @@ public sealed class ChatMessageListView
             var state = getOrInitViewState(item);
             if (state.ShowTimer > 0f)
             {
-                if (NoNewMessagesShowing)
+                if (!active && NewMessagesShowing == NewMessageShowingMode.HideAll)
                 {
                     state.ShowTimer = 0f;
                     state.FadeOut = 0f;

--- a/source/ChatInputBox/ChatInputBox/ChatMessageListView.cs
+++ b/source/ChatInputBox/ChatInputBox/ChatMessageListView.cs
@@ -111,7 +111,7 @@ public sealed class ChatMessageListView
             var state = getOrInitViewState(item);
             if (state.ShowTimer > 0f)
             {
-                if (!active && NewMessagesShowing == NewMessageShowingMode.HideAll)
+                if (NewMessagesShowing == NewMessageShowingMode.HideAll)
                 {
                     state.ShowTimer = 0f;
                     state.FadeOut = 0f;

--- a/source/ChatInputBox/ChatInputBox/ChatMessageManager.cs
+++ b/source/ChatInputBox/ChatInputBox/ChatMessageManager.cs
@@ -74,10 +74,16 @@ public class ChatMessageManager
         else if (targetTabIdx < activeTabIndex)
             activeTabIndex--;
     }
+
+    public void CycleTabForward()
+        => CycleTab(-1);
+
+    public void CycleTabBackward()
+        => CycleTab(1);
     
-    public void CycleTab()
+    public void CycleTab(int offset)
     {
-        activeTabIndex = (activeTabIndex + 2) % (tab.Count + 1) - 1;
+        activeTabIndex = (activeTabIndex + offset + 1) % (tab.Count + 1) - 1;
     }
 
     public void SetActiveTab(string name)

--- a/source/ChatInputBox/ChatInputBox/InputBox.cs
+++ b/source/ChatInputBox/ChatInputBox/InputBox.cs
@@ -96,13 +96,17 @@ public sealed class InputBox
 
     public void Update()
     {
-        if (rightButton.Pressed)
+        if (!MInput.Keyboard.CurrentState.IsKeyDown(Keys.LeftShift) &&
+            !MInput.Keyboard.CurrentState.IsKeyDown(Keys.RightShift) &&
+            rightButton.Pressed)
         {
             rightButton.ConsumePress();
             if (buffer.MoveCaretForward())
                 SetAlwaysShowCaretTimer();
         }
-        else if (leftButton.Pressed)
+        else if (!MInput.Keyboard.CurrentState.IsKeyDown(Keys.LeftShift) &&
+                 !MInput.Keyboard.CurrentState.IsKeyDown(Keys.RightShift) &&
+                 leftButton.Pressed)
         {
             leftButton.ConsumePress();
             if (buffer.MoveCaretBackward())
@@ -141,7 +145,7 @@ public sealed class InputBox
                 }
             }
         }
-        else if (!MInput.Keyboard.CurrentState.IsKeyDown(Keys.LeftShift) && MInput.Keyboard.Pressed(Keys.Tab))
+        else if (MInput.Keyboard.Pressed(Keys.Tab))
         {
             if (completions is not null && (completions.Count == 1 || selectedCompletionIndex != -1))
             {

--- a/source/ChatInputBox/ChatInputBox/docs/chatinputbox.md
+++ b/source/ChatInputBox/ChatInputBox/docs/chatinputbox.md
@@ -54,6 +54,16 @@ public readonly struct Completion
 
 空闲模式只显示最近消息，超过 `ShowDuration` 后淡出；激活模式显示当前标签的较长历史并允许滚动。常用配置包括 `IdleMaxCount`、`ActiveMaxCount`、`ShowDuration`、`BackgroundOpacity` 和 `TextOpacity`。
 
+`ChatMessageListView.NewMessagesShowing` 控制聊天框未激活时的消息来源：
+
+| 模式 | 行为 |
+|---|---|
+| `ShowAll` | 显示全部消息记录 |
+| `WithTab` | 只显示当前活动标签页的消息 |
+| `HideAll` | 不显示新消息 |
+
+聊天框激活后始终显示当前活动标签页，不受该设置影响。
+
 每条 `ChatItem` 可保存 UTC/本地时间来源；渲染时格式化本地时间并和消息绘制在同一背景条中。标签切换只改变视图数据源，不复制 `ChatItem` 内容。
 
 ## 富文本

--- a/source/ChatInputBox/ChatInputBoxExample/ChatInputBoxEntity.cs
+++ b/source/ChatInputBox/ChatInputBoxExample/ChatInputBoxEntity.cs
@@ -134,7 +134,7 @@ public sealed class ChatInputBoxEntity : Entity
             }
             else if (MInput.Keyboard.Pressed(Keys.LeftShift))
             {
-                msgBox.CycleTab();
+                msgBox.CycleTabBackward();
             }
         }
         else if (MInput.Keyboard.Pressed(Keys.T))

--- a/source/MiaoNet.Client/Components/ChatComponent.cs
+++ b/source/MiaoNet.Client/Components/ChatComponent.cs
@@ -130,6 +130,16 @@ public sealed partial class ChatComponent : MiaoNetComponent
         if (received.MentionsSelf)
             Audio.Play(MiaoNetSFX.ChatMention);
     }
+    
+    private void SyncChatChannelWithTab()
+    {
+        var chatTabName = chatMessageBox.ActiveTabName ?? ChatChannelMatcher.GetName(ChatChannel.Global);
+        var chatChannel = ChatChannelMatcher.Match(chatTabName!);
+        if (chatChannel != (ChatChannel)(-1))
+        {
+            MiaoNetModule.Settings.ChatChannel = chatChannel;
+        }
+    }
 
     public override void Update()
     {
@@ -189,16 +199,22 @@ public sealed partial class ChatComponent : MiaoNetComponent
                 Deactivate();
                 return;
             }
-            if (MInput.Keyboard.CurrentState.IsKeyDown(Keys.LeftShift) && MInput.Keyboard.Pressed(Keys.Tab))
+
+            if (MInput.Keyboard.CurrentState.IsKeyDown(Keys.LeftShift) ||
+                MInput.Keyboard.CurrentState.IsKeyDown(Keys.RightShift))
             {
-                chatMessageBox.CycleTab();
-                var chatTabName = chatMessageBox.ActiveTabName ?? ChatChannelMatcher.GetName(ChatChannel.Global);
-                var chatChannel = ChatChannelMatcher.Match(chatTabName!);
-                if (chatChannel != (ChatChannel)(-1))
+                if (MInput.Keyboard.Pressed(Keys.Left))
                 {
-                    settings.ChatChannel = chatChannel;
+                    chatMessageBox.CycleTabForward();
+                    SyncChatChannelWithTab();
+                }
+                else if (MInput.Keyboard.Pressed(Keys.Right))
+                {
+                    chatMessageBox.CycleTabBackward();
+                    SyncChatChannelWithTab();
                 }
             }
+            
 
             if (!inputBox.HasCompletions)
             {

--- a/source/MiaoNet.Client/Components/ChatComponent.cs
+++ b/source/MiaoNet.Client/Components/ChatComponent.cs
@@ -80,7 +80,13 @@ public sealed partial class ChatComponent : MiaoNetComponent
         chatMessageBox.ChatMessageListView.BackgroundOpacity = settings.ChatBackgroundOpacityValue;
         chatMessageBox.ChatMessageListView.TextOpacity = settings.ChatTextOpacityValue;
         chatMessageBox.ChatMessageListView.ShowDuration = settings.ChatDisplayDuration;
-        chatMessageBox.ChatMessageListView.NoNewMessagesShowing = settings.NoNewMessagesShowing;
+        chatMessageBox.ChatMessageListView.NewMessagesShowing = settings.NewMessagesShowing switch
+        {
+            NewMessageShowingMode.ShowAll => global::Celeste.Mod.ChatInputBox.NewMessageShowingMode.ShowAll,
+            NewMessageShowingMode.WithTab => global::Celeste.Mod.ChatInputBox.NewMessageShowingMode.WithTab,
+            NewMessageShowingMode.HideAll => global::Celeste.Mod.ChatInputBox.NewMessageShowingMode.HideAll,
+            _ => global::Celeste.Mod.ChatInputBox.NewMessageShowingMode.ShowAll
+        };
         chatMessageBox.ChatMessageListView.IdleHeight = settings.IdleChatHeightValue;
         chatMessageBox.ChatMessageListView.ActiveHeight = settings.ActiveChatHeightValue;
         float scale = settings.ChatUIScaleValue;

--- a/source/MiaoNet.Client/Game/Settings/MenuMiaoNetOptions.cs
+++ b/source/MiaoNet.Client/Game/Settings/MenuMiaoNetOptions.cs
@@ -384,12 +384,13 @@ public static class MenuMiaoNetOptions
         ).Change(v => settings.PlayerPresenceMessages = v);
         menu.Add(item);
 
-        item = new TextMenu.OnOff(
-            Dialog.Get("miaonet_options_no_new_messages_showing"),
-            settings.NoNewMessagesShowing
-        ).Change(v => settings.NoNewMessagesShowing = v);
+        item = new EnumSlider<NewMessageShowingMode>(
+            Dialog.Get("miaonet_options_new_messages_showing_mode"),
+            value => Dialog.Get($"miaonet_options_new_messages_showing_mode_{value}"),
+            settings.NewMessagesShowing
+        ).Change(v => settings.NewMessagesShowing = v);
         menu.Add(item);
-        item.AddDescription(menu, Dialog.Clean("miaonet_options_no_new_messages_showing_tip"));
+        item.AddDescription(menu, Dialog.Clean("miaonet_options_new_messages_showing_mode_tip"));
 
         #endregion
 

--- a/source/MiaoNet.Client/Game/Settings/MiaoNetModuleSettings.cs
+++ b/source/MiaoNet.Client/Game/Settings/MiaoNetModuleSettings.cs
@@ -216,11 +216,15 @@ public sealed class MiaoNetModuleSettings : EverestModuleSettings,
     public bool PlayerPresenceMessages { get; set; } = true;
 
     [YamlIgnore]
-    public bool NoNewMessagesShowing
+    public NewMessageShowingMode NewMessagesShowing
     {
         get;
-        set { field = value; NotifySettingsChanged(SettingsCategory.VisualsUI); }
-    }
+        set
+        {
+            field = value;
+            NotifySettingsChanged(SettingsCategory.VisualsUI);
+        }
+    } = NewMessageShowingMode.ShowAll;
 
     [YamlIgnore]
     public ChatChannel ChatChannel { get; set; } = ChatChannel.Global;

--- a/source/MiaoNet.Client/Game/Settings/NewMessageShowingMode.cs
+++ b/source/MiaoNet.Client/Game/Settings/NewMessageShowingMode.cs
@@ -1,0 +1,8 @@
+namespace Celeste.Mod.MiaoNet;
+
+public enum NewMessageShowingMode
+{
+    ShowAll,
+    WithTab,
+    HideAll,
+}

--- a/source/MiaoNet.Client/ModFolder/Dialog/English.txt
+++ b/source/MiaoNet.Client/ModFolder/Dialog/English.txt
@@ -93,10 +93,17 @@ miaonet_options_teleport_behaviour= Teleport Command Behaviour
 miaonet_options_teleport_behaviour_nosession= Map and room only
 miaonet_options_teleport_behaviour_withsession= Request other's session
 miaonet_options_player_presence_message= Player Presence Chat Messages
-miaonet_options_no_new_messages_showing= No New Messages Showing
-miaonet_options_no_new_messages_showing_tip=
-	This hides new messages when chat is not open.
+miaonet_options_new_messages_showing_mode= New Messages Showing Mode
+miaonet_options_new_messages_showing_mode_tip=
+	This defines what new messages will be shown when chat is not open.
+	- Show All: Show all the new messages.
+	- With Tab: Maintain new messages filtering consistency with tabs.
+	- Hide All: No new messages showing.
 	This option will not be saved.
+
+miaonet_options_new_messages_showing_mode_showall= Show All
+miaonet_options_new_messages_showing_mode_withtab= With Tab
+miaonet_options_new_messages_showing_mode_hideall= Hide All
 
 miaonet_options_button_chat= Open Chat
 miaonet_options_button_chat_command= Input Commands

--- a/source/MiaoNet.Client/ModFolder/Dialog/Simplified Chinese.txt
+++ b/source/MiaoNet.Client/ModFolder/Dialog/Simplified Chinese.txt
@@ -90,10 +90,16 @@ miaonet_options_teleport_behaviour= Teleport 指令行为
 miaonet_options_teleport_behaviour_nosession= 仅地图和房间
 miaonet_options_teleport_behaviour_withsession= 请求部分存档信息
 miaonet_options_player_presence_message= 聊天栏玩家进出消息
-miaonet_options_no_new_messages_showing= 聊天栏不显示新消息
-miaonet_options_no_new_messages_showing_tip=
-	这会在不打开聊天栏时不显示新的消息
+miaonet_options_new_messages_showing_mode= 聊天栏新消息显示模式
+miaonet_options_new_messages_showing_mode_tip=
+	设置不打开聊天栏时收到新消息的显示行为。
+	- 全部显示：显示所有新消息。
+	- 当前标签页：显示与所选标签页一致的新消息。
+	- 全不显示：不显示新消息。
 	此选项不会被保存。
+miaonet_options_new_messages_showing_mode_showall= 全部显示
+miaonet_options_new_messages_showing_mode_withtab= 当前标签页
+miaonet_options_new_messages_showing_mode_hideall= 全不显示
 
 miaonet_options_button_chat= 打开聊天栏
 miaonet_options_button_chat_command= 输入指令


### PR DESCRIPTION
Issue: #26 
1. 先前的Shift+Tab操作与Steam快捷键冲突：更换为Shift+左右方向键，并处理`InputBox`对方向键的消费以适配。
2. 聊天QoL：部分用户要求可以只查看一部分作用于内的新信息，增加配置项调整新消息的显示模式。