### PR TITLE
修复 Bits&bolts 清理异常导致的客户端断线状态损坏

### DIFF
--- a/source/MiaoNet.Client/Connection/MiaoNetContext.cs
+++ b/source/MiaoNet.Client/Connection/MiaoNetContext.cs
@@ -80,7 +80,7 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
     }
 
     [MemberNotNullWhen(true, nameof(connection), nameof(ClientState), nameof(PlayerPresenceMessage))]
-    public bool HasConnection => connection is not null;
+    public bool HasConnection => connection is not null && clientState is not null;
 
     public ClientState? ClientState => clientState;
 
@@ -185,31 +185,60 @@ public sealed partial class MiaoNetContext : IPacketSerializationContext
         if (!connectionLifecycle.TryEnd(generation.Value))
             return;
 
-        activeConnectionOperation = null;
-        operation.Cancel();
+        // Stop publishing the connection before invoking extensible cleanup code.
+        // A cleanup callback can fail or re-enter this method, but observers must
+        // never see a live connection paired with an already-cleared client state.
         bool hadConnection = connection is not null;
-
-        // any better ways?
-        List<PacketDisconnected>? terminalPackets = null;
-        while (receiveQueue.TryDequeue(out var received))
-        {
-            if (received.Generation == generation.Value && received.Packet is PacketDisconnected dc)
-                (terminalPackets ??= []).Add(dc);
-        }
-        pendingRequests.Clear();
+        activeConnectionOperation = null;
+        connection = null;
         clientState = null;
+        PlayerPresenceMessage = null;
         hasComponentFocus = false;
         PooledStringManager = null;
-        components?.ForEach(c => c.OnDisconnected());
-        connection = null;
-        operation.CloseConnection(false);
+
+        List<PacketDisconnected>? terminalPackets = null;
+        List<CleanupStep> cleanupSteps =
+        [
+            new("cancel connection operation", operation.Cancel),
+            new("drain receive queue", () =>
+            {
+                while (receiveQueue.TryDequeue(out var received))
+                {
+                    if (received.Generation == generation.Value && received.Packet is PacketDisconnected dc)
+                        (terminalPackets ??= []).Add(dc);
+                }
+            }),
+            new("clear pending requests", pendingRequests.Clear),
+        ];
+        if (components is not null)
+        {
+            cleanupSteps.AddRange(components.Select<MiaoNetComponent, CleanupStep>(component =>
+                new($"disconnect component {component.GetType().FullName}", component.OnDisconnected)));
+        }
+
+        List<CleanupStep> finalSteps =
+        [
+            new("close connection operation", () => operation.CloseConnection(false)),
+        ];
         if (hadConnection)
-            AvatarManager.PersistStateToDisk();
+            finalSteps.Add(new("persist avatar state", AvatarManager.PersistStateToDisk));
+
+        List<CleanupFailure> failures = [.. BestEffortCleanup.Run(cleanupSteps, finalSteps)];
 
         if (terminalPackets is not null)
         {
             foreach (PacketDisconnected packet in terminalPackets)
-                packetDispatcher.DispatchPacket(packet);
+            {
+                failures.AddRange(BestEffortCleanup.Run(
+                    [new("dispatch terminal disconnect packet", () => packetDispatcher.DispatchPacket(packet))],
+                    []));
+            }
+        }
+
+        foreach (CleanupFailure failure in failures)
+        {
+            Logger.Error(LT.MiaoNet, $"Failed to {failure.StepName}.");
+            Logger.LogDetailed(failure.Exception, LT.MiaoNet);
         }
     }
 

--- a/source/MiaoNet.Client/ModInterop/BitsboltsCompat.cs
+++ b/source/MiaoNet.Client/ModInterop/BitsboltsCompat.cs
@@ -60,7 +60,12 @@ internal static class BitsboltsCompat
         if (Engine.Scene is not Level level)
             return;
 
-        foreach (GhostDeadBody body in level.Tracker.GetEntities<GhostDeadBody>().ToArray())
+        // GhostDeadBody is tracked through MiaoNetGhostEntity's inherited tracker
+        // entry, so an exact GhostDeadBody entry does not necessarily exist.
+        foreach (GhostDeadBody body in level.Tracker
+            .GetEntities<MiaoNetGhostEntity>()
+            .OfType<GhostDeadBody>()
+            .ToArray())
             body.RemoveSelf();
     }
 }

--- a/source/MiaoNet.ClientShared/BestEffortCleanup.cs
+++ b/source/MiaoNet.ClientShared/BestEffortCleanup.cs
@@ -1,0 +1,45 @@
+namespace MiaoNet.ClientShared;
+
+internal readonly record struct CleanupStep(string Name, Action Action);
+
+internal readonly record struct CleanupFailure(string StepName, Exception Exception);
+
+/// <summary>
+/// Runs independent cleanup steps without allowing one failure to prevent the
+/// remaining steps or the final cleanup steps from running.
+/// </summary>
+internal static class BestEffortCleanup
+{
+    internal static IReadOnlyList<CleanupFailure> Run(
+        IEnumerable<CleanupStep> steps,
+        IEnumerable<CleanupStep> finalSteps)
+    {
+        List<CleanupFailure> failures = [];
+        try
+        {
+            RunSteps(steps, failures);
+        }
+        finally
+        {
+            RunSteps(finalSteps, failures);
+        }
+        return failures;
+    }
+
+    private static void RunSteps(
+        IEnumerable<CleanupStep> steps,
+        List<CleanupFailure> failures)
+    {
+        foreach (CleanupStep step in steps)
+        {
+            try
+            {
+                step.Action();
+            }
+            catch (Exception e)
+            {
+                failures.Add(new(step.Name, e));
+            }
+        }
+    }
+}

--- a/source/MiaoNet.UnitTest/BestEffortCleanupTests.cs
+++ b/source/MiaoNet.UnitTest/BestEffortCleanupTests.cs
@@ -1,0 +1,65 @@
+using MiaoNet.ClientShared;
+
+namespace MiaoNet.UnitTest;
+
+[TestClass]
+public sealed class BestEffortCleanupTests
+{
+    [TestMethod]
+    public void FailingCleanup_DoesNotPreventRemainingOrFinalSteps()
+    {
+        List<string> calls = [];
+        InvalidOperationException expected = new("component cleanup failed");
+
+        IReadOnlyList<CleanupFailure> failures = BestEffortCleanup.Run(
+            [
+                new("first component", () => calls.Add("first")),
+                new("failing component", () => throw expected),
+                new("last component", () => calls.Add("last")),
+            ],
+            [new("close connection", () => calls.Add("close"))]);
+
+        CollectionAssert.AreEqual(
+            new[] { "first", "last", "close" },
+            calls);
+        Assert.HasCount(1, failures);
+        Assert.AreEqual("failing component", failures[0].StepName);
+        Assert.AreSame(expected, failures[0].Exception);
+    }
+
+    [TestMethod]
+    public void FailingFinalStep_DoesNotPreventLaterFinalSteps()
+    {
+        List<string> calls = [];
+
+        IReadOnlyList<CleanupFailure> failures = BestEffortCleanup.Run(
+            [],
+            [
+                new("failing finalizer", () => throw new InvalidOperationException()),
+                new("last finalizer", () => calls.Add("last")),
+            ]);
+
+        CollectionAssert.AreEqual(new[] { "last" }, calls);
+        Assert.HasCount(1, failures);
+        Assert.AreEqual("failing finalizer", failures[0].StepName);
+    }
+
+    [TestMethod]
+    public void CleanupReentry_CannotEndTheSameConnectionTwice()
+    {
+        ConnectionLifecycleCoordinator lifecycle = new();
+        long generation = lifecycle.Begin();
+        Assert.IsTrue(lifecycle.TryEnd(generation));
+
+        int closeCalls = 0;
+        IReadOnlyList<CleanupFailure> failures = BestEffortCleanup.Run(
+            [
+                new("reentrant disconnect", () => Assert.IsFalse(lifecycle.TryEnd(generation))),
+            ],
+            [new("close connection", () => closeCalls++)]);
+
+        Assert.IsEmpty(failures);
+        Assert.AreEqual(1, closeCalls);
+        Assert.AreEqual(ConnectionLifecycleState.Idle, lifecycle.State);
+    }
+}

--- a/source/MiaoNet.UnitTest/MiaoNet.UnitTest.csproj
+++ b/source/MiaoNet.UnitTest/MiaoNet.UnitTest.csproj
@@ -23,6 +23,7 @@
     <Compile Include="..\MiaoNet.Client\Misc\SR.cs" LinkBase="0-Shared/Command" />
     <Compile Include="..\MiaoNet.Client\Misc\PFormat.cs" LinkBase="0-Shared" />
     <Compile Include="..\MiaoNet.ClientShared\ConnectionLifecycleCoordinator.cs" LinkBase="0-Shared" />
+    <Compile Include="..\MiaoNet.ClientShared\BestEffortCleanup.cs" LinkBase="0-Shared" />
     <Compile Include="..\MiaoNet.Shared\SafeGuard.cs" LinkBase="0-Shared/Command" />
     <Compile Include="..\ChatInputBox\ChatInputBox\ChatText*.cs" LinkBase="0-Shared/ChatInputBox" />
   </ItemGroup>


### PR DESCRIPTION
## 问题

加载 Bits&bolts 后，客户端进入断线流程时可能出现以下异常：

    KeyNotFoundException:
    Celeste.Mod.MiaoNet.GhostDeadBody

异常会中断剩余清理，使客户端停留在不一致状态：

    connection != null
    ClientState == null

此后更新和渲染会持续触发 HasState 断言，产生大量重复日志，并且重新连接无法恢复。

## 原因

GhostDeadBody 通过 MiaoNetGhostEntity 的 inherited tracker 条目注册，Tracker 中不一定存在 GhostDeadBody 的精确类型条目。兼容代码直接调用 GetEntities<GhostDeadBody>()，因此在精确类型条目不存在时会抛出 KeyNotFoundException。

同时，原有断线流程先清空 ClientState，再调用各组件的 OnDisconnected()，最后才清空 connection。任意组件的清理过程抛出异常，都会阻止剩余清理继续执行。

## 修改

- 从已注册的 MiaoNetGhostEntity 集合中筛选 GhostDeadBody，不再读取可能不存在的精确类型条目。
- 在调用组件清理前撤销对外可见的连接状态。
- 将各项清理操作独立执行，单个步骤失败不会阻止后续步骤。
- 确保连接关闭和状态持久化仍会执行。
- 保留终止连接包的分发，并记录各项清理失败。
- 增加清理失败、最终清理失败和断线重入测试。

## 验证

- MiaoNet.UnitTest：149 项全部通过。
- MiaoNet.Client Release 编译成功。
- 编译存在一个既有的 MessageXPadding 未使用警告，与本次修改无关。